### PR TITLE
Fixed bug in server.rules.math::calcNewBotSpeed

### DIFF
--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/math.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/math.kt
@@ -22,7 +22,15 @@ fun clamp(value: Double, min: Double, max: Double): Double {
  */
 fun calcNewBotSpeed(currentSpeed: Double, targetSpeed: Double): Double {
     val delta = targetSpeed - currentSpeed
-    return if (currentSpeed >= 0) {
+    return if(currentSpeed==0.0){
+        if(targetSpeed>=0){
+            val step = delta.coerceAtMost(ACCELERATION)
+            (currentSpeed + step).coerceAtMost(MAX_FORWARD_SPEED)
+        }else{
+            val step = (-delta).coerceAtMost(ACCELERATION)
+            (currentSpeed - step).coerceAtLeast(MAX_BACKWARD_SPEED)
+        }
+    }else if (currentSpeed > 0) {
         if (delta >= 0) {
             val step = delta.coerceAtMost(ACCELERATION)
             (currentSpeed + step).coerceAtMost(MAX_FORWARD_SPEED)


### PR DESCRIPTION
Previously, when the currentSpeed = 0, it was possible to accelerate backwards at a limit bound by DECELERATION, rather than ACCELERATION.

```
PREVIOUS OUTPUT:
    ...
    calcNewBotSpeed(0, -0.9) -> -0.9
    calcNewBotSpeed(0, -1)   -> -1
    calcNewBotSpeed(0, -1.1) -> -1.1
    ...
    calcNewBotSpeed(0, -1.9) -> -1.9
    calcNewBotSpeed(0, -2)   -> -2
    calcNewBotSpeed(0, -2.1) -> -2
    ...
```

The condition when currentSpeed = 0 is now evaluated separately from the condition when currentSpeed > 0.

```
CURRENT OUTPUT:
    ...
    calcNewBotSpeed(0, -0.9) -> -0.9
    calcNewBotSpeed(0, -1)   -> -1
    calcNewBotSpeed(0, -1.1) -> -1
    ...
    calcNewBotSpeed(0, -1.9) -> -1
    calcNewBotSpeed(0, -2)   -> -1
    calcNewBotSpeed(0, -2.1) -> -1
    ...
```