### PR TITLE
Handle both minimum and maximum duration for a turn

### DIFF
--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
@@ -62,7 +62,7 @@ class GameServer(
     private var modelUpdater: ModelUpdater? = null
 
     /** Timer for 'ready' timeout */
-    private var readyTimeoutTimer: NanoTimer? = null
+    private lateinit var readyTimeoutTimer: NanoTimer
 
     /** Timer for 'turn' timeout */
     private var turnTimeoutTimer: NanoTimer? = null
@@ -116,10 +116,10 @@ class GameServer(
     private fun startGameIfParticipantsReady() {
         synchronized(startGameLock) {
             if (readyParticipants.size == participants.size) {
+                if (!readyTimeoutTimer.stop()) return
+
                 participantMap.clear()
                 participantMap.putAll(createParticipantMap())
-
-                readyTimeoutTimer?.stop()
 
                 readyParticipants.clear()
                 botIntents.clear()
@@ -173,7 +173,11 @@ class GameServer(
 
     /** Starts the 'ready' timer */
     private fun startReadyTimer() {
-        readyTimeoutTimer = NanoTimer(gameSetup.readyTimeout * 1_000_000L) { onReadyTimeout() }.apply { start() }
+        readyTimeoutTimer = NanoTimer(
+            minPeriodInNanos = 0,
+            maxPeriodInNanos = gameSetup.readyTimeout * 1_000L,
+            job = { onReadyTimeout() }
+        ).apply { start() }
     }
 
     /** Starts a new game */
@@ -251,29 +255,22 @@ class GameServer(
         return participantIds
     }
 
-    /** Last reset turn timeout period */
-    @Volatile
-    var lastResetTurnTimeoutPeriod: Long = 0
-
-    /** Resets turn timeout timer */
+    /** Resets turn timeout timer with min and max bounds */
     private fun resetTurnTimeout() {
-        val period = calculateTurnTimeoutPeriod()
-
-        // New timer is only set, if the period is different from the last reset time
-        if (period != lastResetTurnTimeoutPeriod) {
-            lastResetTurnTimeoutPeriod = period
-
-            // Start new turn timeout timer to invoke onNextTurn()
-            turnTimeoutTimer?.stop()
-            turnTimeoutTimer = NanoTimer(period) { onNextTurn() }.apply { start() }
-        }
+        turnTimeoutTimer?.stop()
+        turnTimeoutTimer = NanoTimer(
+            minPeriodInNanos = calculateTurnTimeoutMinPeriod(),
+            maxPeriodInNanos = calculateTurnTimeoutMaxPeriod(),
+            job = Runnable { onNextTurn() }
+        ).apply { start() }
     }
 
-    /** Calculates and returns a timeout turn period measured in nanoseconds based on current TPS */
-    private fun calculateTurnTimeoutPeriod(): Long {
-        val period = if (tps <= 0) 0 else 1_000_000_000L / tps
-        val turnTimeout = gameSetup.turnTimeout * 1000L
-        return if (turnTimeout > period) turnTimeout else period
+    private fun calculateTurnTimeoutMinPeriod(): Long {
+        return if (tps <= 0) 0 else 1_000_000_000L / tps
+    }
+
+    private fun calculateTurnTimeoutMaxPeriod(): Long {
+        return gameSetup.turnTimeout * 1_000L
     }
 
     /** Broadcast game-aborted event to all observers and controllers */
@@ -400,7 +397,11 @@ class GameServer(
                     onGameEnded()
                 }
             }
+
+            botsThatSentIntent.clear()
         }
+
+        resetTurnTimeout()
     }
 
     private fun onGameEnded() {
@@ -640,12 +641,13 @@ class GameServer(
             botIntents[conn] = this
         }
 
-        // If all bot intents have been received, we can start next turn
-        botsThatSentIntent += conn
-        if (botIntents.size == botsThatSentIntent.size) {
-            botsThatSentIntent.clear()
-            turnTimeoutTimer?.reset()
-            resetTurnTimeout()
+        // Required because the timer also updates botsThatSentIntent
+        synchronized(tickLock) {
+            // If all bot intents have been received, we can start next turn
+            botsThatSentIntent += conn
+            if (botIntents.size == botsThatSentIntent.size) {
+                turnTimeoutTimer?.notifyReady()
+            }
         }
     }
 
@@ -715,7 +717,6 @@ class GameServer(
 
     private fun cleanupAfterGameStopped() {
         turnTimeoutTimer?.stop()
-        lastResetTurnTimeoutPeriod = 0
 
         modelUpdater = null
         System.gc()

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/NanoTimer.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/NanoTimer.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.server.core
 
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
 
 /** NanoTimer is a high-resolution timer with a high precision. */
@@ -46,11 +47,14 @@ class NanoTimer(
     private fun run() {
         while (isRunning.get() && !thread!!.isInterrupted) {
             val now = System.nanoTime()
-            if (now - lastTime >= periodInNanos) {
+            val diff = periodInNanos - (now - lastTime)
+            if (diff <= 0) {
                 lastTime = now
                 if (!isPaused.get()) {
                     job.run()
                 }
+            } else {
+                Thread.sleep(Duration.ofNanos(diff))
             }
         }
         thread = null

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/NanoTimer.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/NanoTimer.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.server.core
 
-import java.time.Duration
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
@@ -58,7 +58,7 @@ class NanoTimer(
     }
 
     override fun run() {
-        var lastTime = System.nanoTime()
+        val lastTime = System.nanoTime()
         if (minPeriodInNanos > 0) {
             while (true) {
                 val now = System.nanoTime()
@@ -66,7 +66,11 @@ class NanoTimer(
                 val isPaused = pauseStartTime.get() != 0L
                 if (diff <= 0 && !isPaused) break
                 try {
-                    Thread.sleep(if (isPaused) Duration.ofSeconds(1) else Duration.ofNanos(diff))
+                    if (isPaused) {
+                        TimeUnit.SECONDS.sleep(1)
+                    } else {
+                        TimeUnit.NANOSECONDS.sleep(diff)
+                    }
                 } catch (e: InterruptedException) {
                     if (jobExecuted.get()) return
                 }
@@ -84,7 +88,11 @@ class NanoTimer(
                 break
             } else {
                 try {
-                    Thread.sleep(if (isPaused) Duration.ofSeconds(1) else Duration.ofNanos(diff))
+                    if (isPaused) {
+                        TimeUnit.SECONDS.sleep(1)
+                    } else {
+                        TimeUnit.NANOSECONDS.sleep(diff)
+                    }
                 } catch (e: InterruptedException) {
                     continue
                 }


### PR DESCRIPTION
This is the PR promised in #117. It is an overhaul of `NanoTimer`, extending it to have both a minimum and maximum wait time. My understanding of the desired game logic is as follows:

- A turn takes AT MOST as long as permitted by the timeout.
- A turn takes AT LEAST as long as 1s/TPS to make sure the game does not run faster than the desired tick speed.
- A turn completes as soon as all bot intents are available.

The old implementation had no notion of two separate bounds. It simply set the turn timeout to `max(1/TPS, turnTimeout)`. The timer did not enforce a lower bound. However, a turn was only completed when the timer elapsed, making it both upper and lower bound at the same time.

While this does mean the game did not run faster than it should, it limits the maximal speed of the game. For the sake of this argument, let's assume we have configured max tick speed, meaning the configured turn timeout is active. Because we always needed to wait for the timer to elapse, the game could run no faster than 1/turnTimeout, even if the bot intents were all available much earlier.

The new implementation rectifies this and permits the game to run as fast as it can. It also makes the strategy for avoiding concurrent calls to onNextTurn more robust. As a general note, I am not convinced that the server in its entirety doesn't currently have concurrency issues unrelated to this PR. I'll need to do a more thorough investigation.