### PR TITLE
Revert behaviour when starting a game on timeout

### DIFF
--- a/schema/schemas/README.md
+++ b/schema/schemas/README.md
@@ -143,7 +143,10 @@ sequenceDiagram
             Server->>Controller: game-started-event-for-observer
             Note over Server: Start turn timeout timer
         else else the game is not started
-            Note over Server: Server state = WAIT_FOR_PARTICIPANTS_TO_JOIN            
+            Note over Server: Server state = WAIT_FOR_PARTICIPANTS_TO_JOIN
+            Server->>Observer: game-aborted-event
+            Server->>Bot: game-aborted-event
+            Server->>Controller: game-aborted-event
         end
     end
 ```

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
@@ -408,6 +408,14 @@ class GameServer(
             if (readyParticipants.size >= gameSetup.minNumberOfParticipants) {
                 // Start the game with the participants that are ready
                 log.warn("Starting game with ${readyParticipants.size}/${participants.size} participants ready because of timeout")
+                val participantIterator = participants.iterator()
+                while (participantIterator.hasNext()) {
+                    val participantConn = participantIterator.next()
+                    if (!readyParticipants.contains(participantConn)) {
+                        participantIterator.remove()
+                        participantIds.remove(participantConn)
+                    }
+                }
                 startGame()
             } else {
                 // Not enough participants -> prepare another game


### PR DESCRIPTION
Restore the original behaviour when the bots that have not confirmed that they are ready in time should not participate, which has been altered by a fix for #132.

