### PR TITLE
#136: Timeout documentation mismatch

### DIFF
--- a/VERSIONS.MD
+++ b/VERSIONS.MD
@@ -16,6 +16,9 @@
 - Sample Bots:
     - The `Fire` and `MyFirstBot` sample bot did not turn perpendicular to the bullet direction anymore, and the RamFire
       did not drive directly towards its target.
+- Documentation:
+    - #136: The turn timeout and ready timeout were incorrectly specified in ~~milliseconds~~ instead of **microseconds**.
+      1 millisecond = 1/1,000 of a second, where 1 microsecond = 1/1,000,000 of a second
 
 ## 📦 0.30.1 - Fixes to sample bots - 08-Mar-2025
 

--- a/bot-api/dotnet/api/src/GameSetup.cs
+++ b/bot-api/dotnet/api/src/GameSetup.cs
@@ -40,12 +40,14 @@ public sealed class GameSetup
     public int? MaxInactivityTurns { get; }
 
     /// <summary>
-    /// Timeout in milliseconds for sending intent after having received 'tick' message.
+    /// Timeout duration in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending intent
+    //// after receiving a 'tick' message.
     /// </summary>
     public int TurnTimeout { get; }
 
     /// <summary>
-    /// Time limit in milliseconds for sending ready message after having received 'new battle' message.
+    /// Time limit in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending a 'ready'
+    /// message after receiving a 'new battle' message.
     /// </summary>
     public int ReadyTimeout { get; }
 

--- a/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/GameSetup.java
+++ b/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/GameSetup.java
@@ -39,12 +39,14 @@ public final class GameSetup {
     private final int maxInactivityTurns;
 
     /**
-     * Timeout in milliseconds for sending intent after having received a 'tick' message.
+     * Timeout duration in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending intent
+     * after receiving a 'tick' message.
      */
     private final int turnTimeout;
 
     /**
-     * Time limit in milliseconds for sending a ready message after having received a 'new battle' message.
+     * Time limit in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending a 'ready'
+     * message after receiving a 'new battle' message.
      */
     private final int readyTimeout;
 
@@ -124,19 +126,18 @@ public final class GameSetup {
     }
 
     /**
-     * Returns the timeout in milliseconds for sending intent after having received 'tick' message.
+     * Returns the timeout in microseconds (µs) for sending intent after having received 'tick' message.
      *
-     * @return The turn timeout in milliseconds.
+     * @return The turn timeout in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second).
      */
     public int getTurnTimeout() {
         return turnTimeout;
     }
 
     /**
-     * Returns the time limit in milliseconds for sending ready message after having received 'new
-     * battle' message.
+     * Returns the time limit in microseconds (µs) for sending ready message after having received 'new battle' message.
      *
-     * @return The ready timeout in milliseconds.
+     * @return The ready timeout in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second).
      */
     public int getReadyTimeout() {
         return readyTimeout;

--- a/bot-api/python/src/robocode_tank_royale/bot_api/game_setup.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/game_setup.py
@@ -24,7 +24,7 @@ class GameSetup:
     """Maximum number of inactive turns allowed, where a bot does not take any action before it is zapped by the game."""
 
     turn_timeout: int
-    """Timeout in milliseconds for sending intent after having received 'tick' message."""
+    """The turn timeout in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second)."""
 
     ready_timeout: int
-    """Time limit in milliseconds for sending ready message after having received 'new battle' message."""
+    """The ready timeout in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second)."""

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
@@ -90,9 +90,9 @@ object GamesSettings : PropertiesStore("Robocode Games Settings", "games.propert
                 isGunCoolingRateLocked = false,
                 maxInactivityTurns = 450,
                 isMaxInactivityTurnsLocked = false,
-                turnTimeout = 30_000, // 30 milliseconds
+                turnTimeout = 30_000, // 30,000 microseconds = 30 milliseconds
                 isTurnTimeoutLocked = false,
-                readyTimeout = 1_000_000, // 1 second
+                readyTimeout = 1_000_000, // 1,000,000 microseconds = 1 second
                 isReadyTimeoutLocked = false,
                 defaultTurnsPerSecond = 30
             )

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
@@ -24,9 +24,9 @@ object GamesSettings : PropertiesStore("Robocode Games Settings", "games.propert
                 isGunCoolingRateLocked = false,
                 maxInactivityTurns = 450,
                 isMaxInactivityTurnsLocked = false,
-                turnTimeout = 30_000, // 30 milliseconds
+                turnTimeout = 30_000, // 30,000 microseconds = 30 milliseconds
                 isTurnTimeoutLocked = false,
-                readyTimeout = 1_000_000, // 1 second
+                readyTimeout = 1_000_000, // 1,000,000 microseconds = 1 second
                 isReadyTimeoutLocked = false,
                 defaultTurnsPerSecond = 30
             ),
@@ -46,9 +46,9 @@ object GamesSettings : PropertiesStore("Robocode Games Settings", "games.propert
                 isGunCoolingRateLocked = true,
                 maxInactivityTurns = 450,
                 isMaxInactivityTurnsLocked = true,
-                turnTimeout = 30_000, // 30 milliseconds
+                turnTimeout = 30_000, // 30,000 microseconds = 30 milliseconds
                 isTurnTimeoutLocked = false,
-                readyTimeout = 1_000_000, // 1 second
+                readyTimeout = 1_000_000, // 1,000,000 microseconds = 1 second
                 isReadyTimeoutLocked = false,
                 defaultTurnsPerSecond = 30
             ),
@@ -68,9 +68,9 @@ object GamesSettings : PropertiesStore("Robocode Games Settings", "games.propert
                 isGunCoolingRateLocked = false,
                 maxInactivityTurns = 450,
                 isMaxInactivityTurnsLocked = false,
-                turnTimeout = 30_000, // 30 milliseconds
+                turnTimeout = 30_000, // 30,000 microseconds = 30 milliseconds
                 isTurnTimeoutLocked = false,
-                readyTimeout = 1_000_000, // 1 second
+                readyTimeout = 1_000_000, // 1,000,000 microseconds = 1 second
                 isReadyTimeoutLocked = false,
                 defaultTurnsPerSecond = 30
             ),
@@ -125,7 +125,7 @@ object GamesSettings : PropertiesStore("Robocode Games Settings", "games.propert
                 "double" -> theField.setDouble(gameType, value.toDouble())
                 "java.lang.Integer" -> theField[gameType] = try {
                     Integer.parseInt(value)
-                } catch (e: NumberFormatException) {
+                } catch (_: NumberFormatException) {
                     null
                 }
                 "java.lang.String" -> theField[gameType] = value

--- a/schema/schemas/game-setup.schema.yaml
+++ b/schema/schemas/game-setup.schema.yaml
@@ -52,15 +52,15 @@ properties:
     description: Flag specifying if the inactive turns is fixed for this game type
     type: boolean
   turnTimeout:
-    description: Turn timeout in microseconds (1 / 1,000,000 second) for sending intent
-      after having received 'tick' message
+    description: Timeout duration in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending
+      intent after receiving a 'tick' message.
     type: integer
   isTurnTimeoutLocked:
     description: Flag specifying if the turn timeout is fixed for this game type
     type: boolean
   readyTimeout:
-    description: Time limit in microseconds (1 / 1,000,000 second) for sending ready
-      message after having received 'game started' message
+    description: Time limit in microseconds (µs) (where 1 microsecond equals 1/1,000,000 of a second) for sending a
+      'ready' message after receiving a 'new battle' message.
     type: integer
   isReadyTimeoutLocked:
     description: Flag specifying if the ready timeout is fixed for this game type

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/core/GameServer.kt
@@ -18,6 +18,8 @@ import org.java_websocket.exceptions.WebsocketNotConnectedException
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.roundToInt
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 
 /** Game server. */
@@ -193,7 +195,7 @@ class GameServer(
     private fun startReadyTimer() {
         readyTimeoutTimer = NanoTimer(
             minPeriodInNanos = 0,
-            maxPeriodInNanos = gameSetup.readyTimeout * 1_000L,
+            maxPeriodInNanos = gameSetup.readyTimeout.inWholeNanoseconds,
             job = { onReadyTimeout() }
         ).apply { start() }
     }
@@ -279,18 +281,18 @@ class GameServer(
     private fun resetTurnTimeout() {
         turnTimeoutTimer?.stop()
         turnTimeoutTimer = NanoTimer(
-            minPeriodInNanos = calculateTurnTimeoutMinPeriod(),
-            maxPeriodInNanos = calculateTurnTimeoutMaxPeriod(),
+            minPeriodInNanos = calculateTurnTimeoutMinPeriod().inWholeNanoseconds,
+            maxPeriodInNanos = calculateTurnTimeoutMaxPeriod().inWholeNanoseconds,
             job = { onNextTurn() }
         ).apply { start() }
     }
 
-    private fun calculateTurnTimeoutMinPeriod(): Long {
-        return if (tps <= 0) 0 else 1_000_000_000L / tps
+    private fun calculateTurnTimeoutMinPeriod(): Duration {
+        return if (tps <= 0) Duration.ZERO else 1_000_000_000.nanoseconds / tps
     }
 
-    private fun calculateTurnTimeoutMaxPeriod(): Long {
-        return gameSetup.turnTimeout * 1_000L
+    private fun calculateTurnTimeoutMaxPeriod(): Duration {
+        return gameSetup.turnTimeout
     }
 
     /** Broadcast game-aborted event to all observers and controllers */

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/GameSetupMapper.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/mapper/GameSetupMapper.kt
@@ -1,6 +1,7 @@
 package dev.robocode.tankroyale.server.mapper
 
 import dev.robocode.tankroyale.server.model.GameSetup
+import kotlin.time.Duration.Companion.microseconds
 
 object GameSetupMapper {
     fun map(gameSetup: GameSetup): dev.robocode.tankroyale.schema.GameSetup {
@@ -14,8 +15,8 @@ object GameSetupMapper {
             setup.numberOfRounds = numberOfRounds
             setup.gunCoolingRate = gunCoolingRate
             setup.maxInactivityTurns = maxInactivityTurns
-            setup.turnTimeout = turnTimeout
-            setup.readyTimeout = readyTimeout
+            setup.turnTimeout = turnTimeout.inWholeMicroseconds.toInt()
+            setup.readyTimeout = readyTimeout.inWholeMicroseconds.toInt()
             setup.defaultTurnsPerSecond = defaultTurnsPerSecond
             setup.isArenaWidthLocked = isArenaWidthLocked
             setup.isArenaHeightLocked = isArenaHeightLocked
@@ -41,8 +42,8 @@ object GameSetupMapper {
                 numberOfRounds = numberOfRounds,
                 gunCoolingRate = gunCoolingRate,
                 maxInactivityTurns = maxInactivityTurns,
-                turnTimeout = turnTimeout,
-                readyTimeout = readyTimeout,
+                turnTimeout = turnTimeout.microseconds,
+                readyTimeout = readyTimeout.microseconds,
                 defaultTurnsPerSecond = defaultTurnsPerSecond,
                 isArenaWidthLocked = isArenaWidthLocked,
                 isArenaHeightLocked = isArenaHeightLocked,

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/model/GameSetup.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/model/GameSetup.kt
@@ -1,6 +1,7 @@
 package dev.robocode.tankroyale.server.model
 
 import dev.robocode.tankroyale.server.rules.*
+import kotlin.time.Duration
 
 /** Game setup. */
 data class GameSetup(
@@ -28,13 +29,13 @@ data class GameSetup(
     /** Number of allowed inactivity turns */
     val maxInactivityTurns: Int = DEFAULT_INACTIVITY_TURNS,
 
-    /** Turn timeout in milliseconds */
-    val turnTimeout: Int = DEFAULT_TURN_TIMEOUT,
+    /** Turn timeout */
+    val turnTimeout: Duration = DEFAULT_TURN_TIMEOUT,
 
-    /** Ready timeout in milliseconds */
-    val readyTimeout: Int = DEFAULT_READY_TIMEOUT,
+    /** Ready timeout */
+    val readyTimeout: Duration = DEFAULT_READY_TIMEOUT,
 
-    /** Default turns per second (TPS) in milliseconds */
+    /** Default turns per second (TPS) */
     val defaultTurnsPerSecond: Int = DEFAULT_TURNS_PER_SECOND,
 
     /** Flag specifying if the arena width is locked */

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/setup.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/setup.kt
@@ -27,5 +27,5 @@ const val DEFAULT_TURN_TIMEOUT = 5000 // 5 milliseconds
 /** Default ready timeout in microseconds (1 / 1,000,000 seconds) */
 const val DEFAULT_READY_TIMEOUT = 1_000_000 // 1 second
 
-/** Default turns per second in milliseconds */
+/** Default turns per second (TPS) */
 const val DEFAULT_TURNS_PER_SECOND = 30

--- a/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/setup.kt
+++ b/server/src/main/kotlin/dev/robocode/tankroyale/server/rules/setup.kt
@@ -1,5 +1,8 @@
 package dev.robocode.tankroyale.server.rules
 
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
 /** Default game type */
 const val DEFAULT_GAME_TYPE = "classic"
 
@@ -21,11 +24,11 @@ const val DEFAULT_GUN_COOLING_RATE = 0.1
 /** Default number of allowed inactivity turns  */
 const val DEFAULT_INACTIVITY_TURNS = 450
 
-/** Default turn timeout in microseconds (1 / 1,000,000 seconds) */
-const val DEFAULT_TURN_TIMEOUT = 5000 // 5 milliseconds
+/** Default turn timeout */
+val DEFAULT_TURN_TIMEOUT = 5.milliseconds
 
-/** Default ready timeout in microseconds (1 / 1,000,000 seconds) */
-const val DEFAULT_READY_TIMEOUT = 1_000_000 // 1 second
+/** Default ready timeout */
+val DEFAULT_READY_TIMEOUT = 1.seconds
 
 /** Default turns per second (TPS) */
 const val DEFAULT_TURNS_PER_SECOND = 30


### PR DESCRIPTION
- Updated documentation for Turn timeout and Ready timeout from milliseconds to microseconds.
- Changed code to use Kotlin's Duration class to specify time units and conversion between these with ease,