### PR TITLE
Extract client from gui-app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ generated/
 /config.properties
 
 /.codiumai/
+/.kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,11 @@ plugins {
     alias(libs.plugins.benmanes.versions) // dependency management only
 }
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
 subprojects {
 
     repositories {

--- a/client-lib/build.gradle.kts
+++ b/client-lib/build.gradle.kts
@@ -1,0 +1,59 @@
+import java.nio.file.Files
+
+description = "Robocode Tank Royale Client Lib for Java"
+
+val javadocTitle = "Robocode Tank Royale Client"
+group = "dev.robocode.tankroyale"
+version = libs.versions.tankroyale.get()
+
+base {
+    archivesName = "robocode-tankroyale-client" // renames _all_ archive names
+}
+
+plugins {
+    `java-library`
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(testLibs.kotest.junit5)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+
+    withJavadocJar()
+    withSourcesJar()
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+        failFast = true
+    }
+
+    javadoc {
+        title = "$javadocTitle $version"
+        source(sourceSets.main.get().allJava)
+
+        (options as StandardJavadocDocletOptions).apply {
+            memberLevel = JavadocMemberLevel.PROTECTED
+            overview = layout.projectDirectory.file("src/main/javadoc/overview.html").asFile.path
+
+            addFileOption("-add-stylesheet", layout.projectDirectory.file("src/main/javadoc/themes/prism.css").asFile)
+            addBooleanOption("-allow-script-in-comments", true)
+            addStringOption("Xdoclint:none", "-quiet")
+        }
+        doLast {
+            val sourceFile = layout.projectDirectory.file("src/main/javadoc/prism.js").asFile.toPath()
+            val targetFile = layout.buildDirectory.file("docs/javadoc/prism.js").get().asFile.toPath()
+            Files.copy(sourceFile, targetFile)
+        }
+    }
+
+}

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/Event.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/Event.kt
@@ -1,6 +1,7 @@
-package dev.robocode.tankroyale.gui.util
+package dev.robocode.tankroyale.client
 
-import java.util.*
+import java.util.Collections
+import java.util.WeakHashMap
 
 /**
  * Used for defining an event handler. The thread handler is thread-safe and uses a WeakHashMap to get rid of event
@@ -58,20 +59,6 @@ open class Event<T> {
                 eventHandler.invoke(event)
             }
         }
-    }
-
-    /**
-     * Enqueues a task on the Event Queue that must be invoked later.
-     *
-     * Example of usage:
-     * ```
-     * onEvent.enqueue { myDialog.isVisible = true }
-     * ```
-     * @param owner is the owner of the event handler, typically `this` instance.
-     * @param callable is used for providing the event handler function.
-     */
-    fun enqueue(owner: Any, callable: () -> Unit) {
-        subscribe(owner) { EDT.enqueue { callable.invoke() } }
     }
 
     class Handler<T>(

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/WebSocketClient.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/WebSocketClient.kt
@@ -1,7 +1,7 @@
-package dev.robocode.tankroyale.gui.client
+package dev.robocode.tankroyale.client
 
-import dev.robocode.tankroyale.gui.model.Message
-import dev.robocode.tankroyale.gui.model.MessageConstants
+import dev.robocode.tankroyale.client.model.Message
+import dev.robocode.tankroyale.client.model.MessageConstants
 import kotlinx.serialization.PolymorphicSerializer
 import java.net.URI
 import java.net.http.HttpClient

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/WebSocketClientEvents.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/WebSocketClientEvents.kt
@@ -1,6 +1,4 @@
-package dev.robocode.tankroyale.gui.client
-
-import dev.robocode.tankroyale.gui.util.Event
+package dev.robocode.tankroyale.client
 
 object WebSocketClientEvents {
     val onOpen = Event<Unit>()

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotAddress.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotAddress.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotInfo.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotInfo.kt
@@ -1,7 +1,7 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
-import java.util.Objects
+import java.util.*
 
 @Serializable
 data class BotInfo(

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotState.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BotState.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BulletState.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/BulletState.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/GameSetup.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/GameSetup.kt
@@ -1,6 +1,5 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
-import dev.robocode.tankroyale.gui.settings.MutableGameSetup
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -25,30 +24,4 @@ data class GameSetup(
     override val readyTimeout: Int,
     override val isReadyTimeoutLocked: Boolean,
     override val defaultTurnsPerSecond: Int
-) : IGameSetup {
-
-    fun toMutableGameSetup(): MutableGameSetup {
-        return MutableGameSetup(
-            gameType,
-            arenaWidth,
-            isArenaWidthLocked,
-            arenaHeight,
-            isArenaHeightLocked,
-            minNumberOfParticipants,
-            isMinNumberOfParticipantsLocked,
-            maxNumberOfParticipants,
-            isMaxNumberOfParticipantsLocked,
-            numberOfRounds,
-            isNumberOfRoundsLocked,
-            gunCoolingRate,
-            isGunCoolingRateLocked,
-            maxInactivityTurns,
-            isMaxInactivityTurnsLocked,
-            turnTimeout,
-            isTurnTimeoutLocked,
-            readyTimeout,
-            isReadyTimeoutLocked,
-            defaultTurnsPerSecond
-        )
-    }
-}
+) : IGameSetup

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/IGameSetup.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/IGameSetup.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.SerialName
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/InitialPosition.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/InitialPosition.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Messages.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Messages.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.SerialName

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Participant.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Participant.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.Serializable
 

--- a/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Results.kt
+++ b/client-lib/src/main/kotlin/dev/robocode/tankroyale/client/model/Results.kt
@@ -1,4 +1,4 @@
-package dev.robocode.tankroyale.gui.model
+package dev.robocode.tankroyale.client.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/client-lib/src/test/kotlin/dev/robocode/tankroyale/client/EventTest.kt
+++ b/client-lib/src/test/kotlin/dev/robocode/tankroyale/client/EventTest.kt
@@ -1,0 +1,124 @@
+package dev.robocode.tankroyale.client
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicInteger
+
+class EventTest : FunSpec({
+
+    context("Event class") {
+
+        test("subscribe and fire") {
+            val event = Event<String>()
+            val result = mutableListOf<String>()
+
+            event.subscribe(this) { result.add(it) }
+            event.fire("test")
+
+            result shouldBe listOf("test")
+        }
+
+        test("unsubscribe") {
+            val event = Event<String>()
+            val result = mutableListOf<String>()
+
+            event.subscribe(this) { result.add(it) }
+            event.fire("test1")
+            event.unsubscribe(this)
+            event.fire("test2")
+
+            result shouldBe listOf("test1")
+        }
+
+        test("subscribe once") {
+            val event = Event<String>()
+            val result = mutableListOf<String>()
+
+            event.subscribe(this, once = true) { result.add(it) }
+            event.fire("test1")
+            event.fire("test2")
+
+            result shouldBe listOf("test1")
+        }
+
+        test("multiple subscribers") {
+            val event = Event<String>()
+            val result1 = mutableListOf<String>()
+            val result2 = mutableListOf<String>()
+
+            event.subscribe("subscriber1") { result1.add(it) }
+            event.subscribe("subscriber2") { result2.add(it) }
+            event.fire("test")
+
+            result1 shouldBe listOf("test")
+            result2 shouldBe listOf("test")
+        }
+
+        test("Handler class") {
+            val handler = Event.Handler<String>({ }, true)
+
+            handler.shouldBeInstanceOf<Event.Handler<String>>()
+            handler.once shouldBe true
+        }
+
+        test("subscriber is removed when owner is garbage collected") {
+            val event = Event<String>()
+            val result = AtomicInteger(0)
+
+            class Subscriber {
+                fun handleEvent(msg: String) {
+                    result.incrementAndGet()
+                }
+            }
+
+            var subscriber: Subscriber? = Subscriber()
+            val weakRef = WeakReference(subscriber)
+
+            event.subscribe(subscriber!!) { msg ->
+                weakRef.get()?.handleEvent(msg)
+            }
+
+            // Verify that the subscriber is initially present
+            event.fire("test")
+            result.get() shouldBe 1
+
+            // Remove strong reference to subscriber and force garbage collection
+            subscriber = null
+            System.gc()
+            Thread.sleep(100)
+
+            // Fire the event again
+            event.fire("test")
+
+            // The result should still be 1 because the subscriber should have been removed
+            result.get() shouldBe 1
+
+            // Verify that the eventHandlers map is empty
+            val eventHandlersField = Event::class.java.getDeclaredField("eventHandlers")
+            eventHandlersField.isAccessible = true
+            val eventHandlers = eventHandlersField.get(event) as Map<*, *>
+            eventHandlers.shouldBeEmpty()
+        }
+
+        test("subscriber reference type") {
+            val event = Event<String>()
+            val subscriber = object : Any() {}
+
+            event.subscribe(subscriber) { }
+
+            // Use reflection to access the private eventHandlers field
+            val eventHandlersField = Event::class.java.getDeclaredField("eventHandlers")
+            eventHandlersField.isAccessible = true
+            val eventHandlers = eventHandlersField.get(event) as Map<*, *>
+
+            // Check that the value in the eventHandlers map is our Handler class
+            eventHandlers.values.first().shouldBeInstanceOf<Event.Handler<String>>()
+
+            // Check that the key in the eventHandlers map is our subscriber object
+            eventHandlers.keys.first() shouldBe subscriber
+        }
+    }
+})

--- a/gui-app/build.gradle.kts
+++ b/gui-app/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":client-lib"))
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.miglayout.swing)
     implementation(libs.jsvg)

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/audio/SoundActions.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/audio/SoundActions.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.audio
 
+import dev.robocode.tankroyale.client.model.*
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.*
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.settings.ConfigSettings.SOUNDS_DIR
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/booter/BootProcess.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/booter/BootProcess.kt
@@ -1,9 +1,9 @@
 package dev.robocode.tankroyale.gui.booter
 
-import dev.robocode.tankroyale.gui.model.MessageConstants
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.MessageConstants
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.settings.ServerSettings
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.FileUtil
 import dev.robocode.tankroyale.gui.util.ResourceUtil
 import java.io.BufferedReader

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
@@ -1,5 +1,8 @@
 package dev.robocode.tankroyale.gui.client
 
+import dev.robocode.tankroyale.client.WebSocketClient
+import dev.robocode.tankroyale.client.WebSocketClientEvents
+import dev.robocode.tankroyale.client.model.*
 import dev.robocode.tankroyale.gui.client.ClientEvents.onBotListUpdate
 import dev.robocode.tankroyale.gui.client.ClientEvents.onConnected
 import dev.robocode.tankroyale.gui.client.ClientEvents.onGameAborted
@@ -10,7 +13,6 @@ import dev.robocode.tankroyale.gui.client.ClientEvents.onGameStarted
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundEnded
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundStarted
 import dev.robocode.tankroyale.gui.client.ClientEvents.onTickEvent
-import dev.robocode.tankroyale.gui.model.*
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.settings.GamesSettings
 import dev.robocode.tankroyale.gui.settings.ServerSettings

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.client
 
-import dev.robocode.tankroyale.gui.model.*
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.*
 
 object ClientEvents {
     val onConnected = Event<Unit>()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/GamesSettings.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.settings
 
-import dev.robocode.tankroyale.gui.model.GameSetup
-import dev.robocode.tankroyale.gui.model.IGameSetup
+import dev.robocode.tankroyale.client.model.GameSetup
+import dev.robocode.tankroyale.client.model.IGameSetup
 import java.util.*
 
 object GamesSettings : PropertiesStore("Robocode Games Settings", "games.properties") {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/MutableGameSetup.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/MutableGameSetup.kt
@@ -1,6 +1,7 @@
 package dev.robocode.tankroyale.gui.settings
 
-import dev.robocode.tankroyale.gui.model.IGameSetup
+import dev.robocode.tankroyale.client.model.GameSetup
+import dev.robocode.tankroyale.client.model.IGameSetup
 
 data class MutableGameSetup(
     override var gameType: String,
@@ -47,4 +48,29 @@ data class MutableGameSetup(
         isReadyTimeoutLocked = other.isReadyTimeoutLocked
         defaultTurnsPerSecond = other.defaultTurnsPerSecond
     }
+}
+
+fun GameSetup.toMutableGameSetup(): MutableGameSetup {
+    return MutableGameSetup(
+        gameType,
+        arenaWidth,
+        isArenaWidthLocked,
+        arenaHeight,
+        isArenaHeightLocked,
+        minNumberOfParticipants,
+        isMinNumberOfParticipantsLocked,
+        maxNumberOfParticipants,
+        isMaxNumberOfParticipantsLocked,
+        numberOfRounds,
+        isNumberOfRoundsLocked,
+        gunCoolingRate,
+        isGunCoolingRateLocked,
+        maxInactivityTurns,
+        isMaxInactivityTurnsLocked,
+        turnTimeout,
+        isTurnTimeoutLocked,
+        readyTimeout,
+        isReadyTimeoutLocked,
+        defaultTurnsPerSecond
+    )
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/PropertiesStore.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/settings/PropertiesStore.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.settings
 
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileWriter

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/ResultsFrame.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/ResultsFrame.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.ui
 
+import dev.robocode.tankroyale.client.model.Results
 import dev.robocode.tankroyale.gui.client.Client
-import dev.robocode.tankroyale.gui.model.Results
 import dev.robocode.tankroyale.gui.ui.components.RcFrame
 import dev.robocode.tankroyale.gui.ui.components.RcToolTip
 import java.awt.Component

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/about/AboutBox.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/about/AboutBox.kt
@@ -1,17 +1,19 @@
 package dev.robocode.tankroyale.gui.ui.about
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.ui.MainFrame
 import dev.robocode.tankroyale.gui.ui.components.RcDialog
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addOkButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.setDefaultButton
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onActivated
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.JavaVersion
 import dev.robocode.tankroyale.gui.util.Version
 import net.miginfocom.swing.MigLayout
 import java.awt.Container
 import java.net.URL
-import javax.swing.*
+import javax.swing.JButton
+import javax.swing.JEditorPane
+import javax.swing.JPanel
 
 
 object AboutBox : RcDialog(MainFrame, "about_dialog") {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
@@ -1,8 +1,8 @@
 package dev.robocode.tankroyale.gui.ui.arena
 
+import dev.robocode.tankroyale.client.model.*
 import dev.robocode.tankroyale.gui.client.Client
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.*
 import dev.robocode.tankroyale.gui.ui.ResultsFrame
 import dev.robocode.tankroyale.gui.ui.extensions.ColorExt.hsl
 import dev.robocode.tankroyale.gui.ui.extensions.ColorExt.lightness
@@ -14,12 +14,7 @@ import dev.robocode.tankroyale.gui.util.ColorUtil.Companion.fromString
 import dev.robocode.tankroyale.gui.util.Graphics2DState
 import dev.robocode.tankroyale.gui.util.HslColor
 import java.awt.*
-import java.awt.event.ComponentAdapter
-import java.awt.event.ComponentEvent
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
-import java.awt.event.MouseMotionAdapter
-import java.awt.event.MouseWheelEvent
+import java.awt.event.*
 import java.awt.geom.AffineTransform
 import java.awt.geom.Arc2D
 import java.awt.geom.Area

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/BotButton.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/BotButton.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.arena
 
-import dev.robocode.tankroyale.gui.model.Participant
+import dev.robocode.tankroyale.client.model.Participant
 import java.awt.Dimension
 import javax.swing.JButton
 import javax.swing.SwingConstants

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/SidePanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/SidePanel.kt
@@ -1,11 +1,11 @@
 package dev.robocode.tankroyale.gui.ui.arena
 
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.GameStartedEvent
+import dev.robocode.tankroyale.client.model.Participant
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.GameStartedEvent
-import dev.robocode.tankroyale.gui.model.Participant
 import dev.robocode.tankroyale.gui.ui.console.BotConsoleFrame
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onClosing
-import dev.robocode.tankroyale.gui.util.Event
 import java.awt.Dimension
 import javax.swing.BoxLayout
 import javax.swing.JButton

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/Tank.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/Tank.kt
@@ -1,13 +1,13 @@
 package dev.robocode.tankroyale.gui.ui.arena
 
-import dev.robocode.tankroyale.gui.model.BotState
+import dev.robocode.tankroyale.client.model.BotState
 import dev.robocode.tankroyale.gui.ui.arena.ColorConstant.DEFAULT_BODY_COLOR
 import dev.robocode.tankroyale.gui.ui.arena.ColorConstant.DEFAULT_GUN_COLOR
 import dev.robocode.tankroyale.gui.ui.arena.ColorConstant.DEFAULT_RADAR_COLOR
 import dev.robocode.tankroyale.gui.ui.arena.ColorConstant.DEFAULT_TRACKS_COLOR
 import dev.robocode.tankroyale.gui.ui.arena.ColorConstant.DEFAULT_TURRET_COLOR
-import dev.robocode.tankroyale.gui.ui.extensions.ColorExt.lightness
 import dev.robocode.tankroyale.gui.ui.extensions.ColorExt.hsl
+import dev.robocode.tankroyale.gui.ui.extensions.ColorExt.lightness
 import dev.robocode.tankroyale.gui.util.ColorUtil.Companion.fromString
 import java.awt.BasicStroke
 import java.awt.Color

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SortedListModel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SortedListModel.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.components
 
-import dev.robocode.tankroyale.gui.model.BotInfo
+import dev.robocode.tankroyale.client.model.BotInfo
 import java.awt.EventQueue
 import java.util.*
 import javax.swing.AbstractListModel

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/BotRootDirectoriesConfigDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/BotRootDirectoriesConfigDialog.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.config
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.settings.BotDirectoryConfig
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.ui.MainFrame
@@ -12,10 +13,12 @@ import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.setDefaultButton
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onActivated
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onClosing
 import dev.robocode.tankroyale.gui.util.EDT
-import dev.robocode.tankroyale.gui.util.Event
 import net.miginfocom.swing.MigLayout
 import java.awt.Dimension
-import java.awt.event.*
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.*
 
 object BotRootDirectoriesConfigDialog : RcDialog(MainFrame, "bot_root_directories_config_dialog") {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/DebugConfigDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/DebugConfigDialog.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.config
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.settings.ServerSettings
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.MainFrame
@@ -7,7 +8,6 @@ import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.components.RcDialog
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addOkButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.setDefaultButton
-import dev.robocode.tankroyale.gui.util.Event
 import net.miginfocom.swing.MigLayout
 import javax.swing.JButton
 import javax.swing.JCheckBox

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/ServerConfigDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/ServerConfigDialog.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.config
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.settings.ServerSettings
 import dev.robocode.tankroyale.gui.ui.MainFrame
 import dev.robocode.tankroyale.gui.ui.Messages
@@ -20,16 +21,15 @@ import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.showMessage
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onClosed
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onOpened
 import dev.robocode.tankroyale.gui.ui.server.RemoteServer
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.MessageDialog
 import net.miginfocom.swing.MigLayout
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.Font
 import java.awt.event.ActionListener
-import javax.swing.*
 import java.awt.event.ItemEvent
 import java.awt.event.ItemListener
+import javax.swing.*
 
 class ServerConfigDialog : RcDialog(MainFrame, "server_config_dialog") {
     init {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/SetupRulesDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/SetupRulesDialog.kt
@@ -1,10 +1,15 @@
 package dev.robocode.tankroyale.gui.ui.config
 
-import dev.robocode.tankroyale.gui.model.IGameSetup
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.IGameSetup
 import dev.robocode.tankroyale.gui.settings.GameType
 import dev.robocode.tankroyale.gui.settings.GamesSettings
 import dev.robocode.tankroyale.gui.settings.MutableGameSetup
-import dev.robocode.tankroyale.gui.ui.*
+import dev.robocode.tankroyale.gui.settings.toMutableGameSetup
+import dev.robocode.tankroyale.gui.ui.GameConstants
+import dev.robocode.tankroyale.gui.ui.MainFrame
+import dev.robocode.tankroyale.gui.ui.Messages
+import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.components.RcDialog
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addCancelButton
@@ -16,9 +21,11 @@ import dev.robocode.tankroyale.gui.ui.extensions.JTextFieldExt.onChange
 import dev.robocode.tankroyale.gui.ui.extensions.JTextFieldExt.setInputVerifier
 import dev.robocode.tankroyale.gui.ui.extensions.WindowExt.onActivated
 import dev.robocode.tankroyale.gui.ui.newbattle.GameTypeDropdown
-import dev.robocode.tankroyale.gui.util.Event
 import net.miginfocom.swing.MigLayout
-import javax.swing.*
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JPanel
+import javax.swing.JTextField
 
 object SetupRulesDialog : RcDialog(MainFrame, "setup_rules_dialog") {
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/SoundConfigDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/config/SoundConfigDialog.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.config
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.settings.ConfigSettings.SOUNDS_DIR
 import dev.robocode.tankroyale.gui.ui.MainFrame
@@ -10,7 +11,6 @@ import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addCheckBox
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addOkButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.setDefaultButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.showError
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.FileUtil
 import net.miginfocom.swing.MigLayout
 import javax.swing.BorderFactory

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BaseBotConsolePanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BaseBotConsolePanel.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.console
 
+import dev.robocode.tankroyale.client.model.Participant
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.Participant
 import dev.robocode.tankroyale.gui.ui.Strings
 
 abstract class BaseBotConsolePanel(val bot: Participant) : ConsolePanel() {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotConsoleFrame.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotConsoleFrame.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.console
 
-import dev.robocode.tankroyale.gui.model.Participant
+import dev.robocode.tankroyale.client.model.Participant
 import dev.robocode.tankroyale.gui.ui.Strings
 import javax.swing.JTabbedPane
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotConsolePanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotConsolePanel.kt
@@ -1,9 +1,9 @@
 package dev.robocode.tankroyale.gui.ui.console
 
+import dev.robocode.tankroyale.client.model.BotDeathEvent
+import dev.robocode.tankroyale.client.model.Participant
 import dev.robocode.tankroyale.gui.client.Client
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.BotDeathEvent
-import dev.robocode.tankroyale.gui.model.Participant
 import dev.robocode.tankroyale.gui.ui.Strings
 
 class BotConsolePanel(bot: Participant) : BaseBotConsolePanel(bot) {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotEventsPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotEventsPanel.kt
@@ -1,11 +1,11 @@
 package dev.robocode.tankroyale.gui.ui.console
 
+import dev.robocode.tankroyale.client.model.*
 import dev.robocode.tankroyale.gui.ansi.AnsiTextBuilder
 import dev.robocode.tankroyale.gui.ansi.esc_code.CommandCode
 import dev.robocode.tankroyale.gui.ansi.esc_code.EscapeSequence
 import dev.robocode.tankroyale.gui.client.Client
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.*
 
 // TODO: Optimize: Only log for current turn
 // TODO: Missing listing bullet values for the tick event

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotPropertiesPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BotPropertiesPanel.kt
@@ -1,10 +1,10 @@
 package dev.robocode.tankroyale.gui.ui.console
 
+import dev.robocode.tankroyale.client.model.BotPolicyUpdate
+import dev.robocode.tankroyale.client.model.Participant
+import dev.robocode.tankroyale.client.model.TickEvent
 import dev.robocode.tankroyale.gui.client.Client
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.Participant
-import dev.robocode.tankroyale.gui.model.BotPolicyUpdate
-import dev.robocode.tankroyale.gui.model.TickEvent
 import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.components.SwitchButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addLabel

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/ConsolePanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/ConsolePanel.kt
@@ -1,12 +1,12 @@
 package dev.robocode.tankroyale.gui.ui.console
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.ansi.AnsiEditorPane
 import dev.robocode.tankroyale.gui.ansi.AnsiTextBuilder
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addButton
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addOkButton
 import dev.robocode.tankroyale.gui.util.Clipboard
 import dev.robocode.tankroyale.gui.util.EDT
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.EscapedTextDecoder
 import java.awt.BorderLayout
 import javax.swing.*

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlEventHandlers.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlEventHandlers.kt
@@ -1,6 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.control
 
 import dev.robocode.tankroyale.gui.client.Client
+import dev.robocode.tankroyale.gui.util.enqueue
 
 object ControlEventHandlers {
     init {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlEvents.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.control
 
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
 import javax.swing.JButton
 
 object ControlEvents {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
@@ -1,8 +1,9 @@
 package dev.robocode.tankroyale.gui.ui.control
 
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.TpsChangedEvent
 import dev.robocode.tankroyale.gui.client.ClientEvents
 import dev.robocode.tankroyale.gui.client.ClientEvents.onGameStarted
-import dev.robocode.tankroyale.gui.model.TpsChangedEvent
 import dev.robocode.tankroyale.gui.settings.ConfigSettings.DEFAULT_TPS
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.Strings
@@ -12,7 +13,6 @@ import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.setDefaultButton
 import dev.robocode.tankroyale.gui.ui.tps.TpsEvents
 import dev.robocode.tankroyale.gui.ui.tps.TpsField
 import dev.robocode.tankroyale.gui.ui.tps.TpsSlider
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.RegisterWsProtocol
 import java.awt.EventQueue
 import javax.swing.JButton

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/extensions/JComponentExt.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/extensions/JComponentExt.kt
@@ -1,13 +1,16 @@
 package dev.robocode.tankroyale.gui.ui.extensions
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.components.RcToolTip
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.MessageDialog
 import java.awt.Component
 import java.awt.Container
 import java.awt.EventQueue
-import javax.swing.*
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComponent
+import javax.swing.JLabel
 
 object JComponentExt {
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/extensions/JMenuExt.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/extensions/JMenuExt.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.extensions
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.ui.MenuTitles
-import dev.robocode.tankroyale.gui.util.Event
 import javax.swing.JMenu
 import javax.swing.JMenuItem
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/menu/MenuEventTriggers.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/menu/MenuEventTriggers.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.menu
 
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
 import javax.swing.JMenuItem
 
 object MenuEventTriggers {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotDirectoryListCellRenderer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotDirectoryListCellRenderer.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
-import dev.robocode.tankroyale.gui.model.BotInfo
+import dev.robocode.tankroyale.client.model.BotInfo
 import javax.swing.JList
 
 class BotDirectoryListCellRenderer : AbstractListCellRenderer() {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotInfoListCellRenderer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotInfoListCellRenderer.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
-import dev.robocode.tankroyale.gui.model.BotInfo
+import dev.robocode.tankroyale.client.model.BotInfo
 import javax.swing.JList
 
 class BotInfoListCellRenderer : AbstractListCellRenderer() {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotInfoPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotInfoPanel.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
-import dev.robocode.tankroyale.gui.model.BotInfo
+import dev.robocode.tankroyale.client.model.BotInfo
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addLabel
 import net.miginfocom.swing.MigLayout
 import java.awt.Desktop
@@ -69,7 +69,7 @@ object BotInfoPanel : JPanel(MigLayout("", "[][sg,grow][10][][sg,grow]")) {
         versionTextField.text = botInfo?.version
         authorsTextField.text = botInfo?.authors?.joinToString(separator = ", ") ?: ""
         descriptionTextField.text = botInfo?.description?.let { truncateDescriptionLines(it) } ?: ""
-        homepageTextPane.text = botInfo?.homepage?.let { generateUrlHtml(botInfo.homepage) } ?: ""
+        homepageTextPane.text = botInfo?.homepage?.let { generateUrlHtml(it) } ?: ""
         gameTypesTextField.text = botInfo?.gameTypes?.joinToString(separator = ", ") ?: ""
         countryCodesTextPane.text = botInfo?.countryCodes?.let { generateCountryHtml(botInfo.countryCodes) } ?: ""
         platformTextField.text = botInfo?.platform

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotList.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotList.kt
@@ -1,8 +1,8 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
+import dev.robocode.tankroyale.client.Event
 import dev.robocode.tankroyale.gui.ui.components.RcList
 import dev.robocode.tankroyale.gui.ui.components.SortedListModel
-import dev.robocode.tankroyale.gui.util.Event
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotSelectionEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotSelectionEvents.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
-import dev.robocode.tankroyale.gui.model.BotInfo
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.BotInfo
 
 object BotSelectionEvents {
     val onBotDirectorySelected = Event<BotInfo>()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotSelectionPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/BotSelectionPanel.kt
@@ -1,10 +1,11 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.BotInfo
 import dev.robocode.tankroyale.gui.booter.BootProcess
 import dev.robocode.tankroyale.gui.booter.DirAndPid
 import dev.robocode.tankroyale.gui.client.Client
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.model.BotInfo
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.Messages
@@ -19,7 +20,6 @@ import dev.robocode.tankroyale.gui.ui.extensions.JListExt.onChanged
 import dev.robocode.tankroyale.gui.ui.extensions.JListExt.onMultiClickedAtIndex
 import dev.robocode.tankroyale.gui.ui.extensions.JListExt.onSelection
 import dev.robocode.tankroyale.gui.ui.server.ServerEvents
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.EDT.enqueue
 import net.miginfocom.swing.MigLayout
 import java.awt.EventQueue

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/NewBattleDialog.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/newbattle/NewBattleDialog.kt
@@ -1,25 +1,27 @@
 package dev.robocode.tankroyale.gui.ui.newbattle
 
-import dev.robocode.tankroyale.gui.ui.MainFrame
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.BotInfo
 import dev.robocode.tankroyale.gui.client.Client
-import dev.robocode.tankroyale.gui.model.BotInfo
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.settings.GamesSettings
 import dev.robocode.tankroyale.gui.ui.Hints
+import dev.robocode.tankroyale.gui.ui.MainFrame
 import dev.robocode.tankroyale.gui.ui.Messages
+import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.components.RcDialog
 import dev.robocode.tankroyale.gui.ui.config.SetupRulesDialog
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addButton
-import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addLabel
-import dev.robocode.tankroyale.gui.ui.Strings
 import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addCancelButton
+import dev.robocode.tankroyale.gui.ui.extensions.JComponentExt.addLabel
 import dev.robocode.tankroyale.gui.ui.server.ServerEvents
-import dev.robocode.tankroyale.gui.util.Event
 import dev.robocode.tankroyale.gui.util.MessageDialog
 import net.miginfocom.swing.MigLayout
 import java.awt.Dimension
 import java.awt.event.ItemEvent
-import javax.swing.*
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JPanel
 
 object NewBattleDialog : RcDialog(MainFrame, "select_bots_dialog") {
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/server/ServerEventTriggers.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/server/ServerEventTriggers.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.server
 
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
 
 object ServerEventTriggers {
     val onStartLocalServer = Event<Unit>()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/server/ServerEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/server/ServerEvents.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.server
 
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
 
 object ServerEvents {
     val onConnected = Event<Unit>()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsEvents.kt
@@ -1,7 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.tps
 
-import dev.robocode.tankroyale.gui.model.TpsChangedEvent
-import dev.robocode.tankroyale.gui.util.Event
+import dev.robocode.tankroyale.client.Event
+import dev.robocode.tankroyale.client.model.TpsChangedEvent
 
 object TpsEvents {
     val onTpsChanged = Event<TpsChangedEvent>()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsField.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsField.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.tps
 
-import dev.robocode.tankroyale.gui.model.TpsChangedEvent
+import dev.robocode.tankroyale.client.model.TpsChangedEvent
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.ui.Messages
 import dev.robocode.tankroyale.gui.ui.components.RcLimitedTextField

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/tps/TpsSlider.kt
@@ -1,6 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.tps
 
-import dev.robocode.tankroyale.gui.model.TpsChangedEvent
+import dev.robocode.tankroyale.client.model.TpsChangedEvent
 import dev.robocode.tankroyale.gui.settings.ConfigSettings
 import dev.robocode.tankroyale.gui.ui.components.RcSlider
 import java.awt.Dimension

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/util/EDT.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/util/EDT.kt
@@ -1,5 +1,6 @@
 package dev.robocode.tankroyale.gui.util
 
+import dev.robocode.tankroyale.client.Event
 import java.awt.EventQueue
 
 object EDT {
@@ -14,4 +15,18 @@ object EDT {
             }
         }
     }
+}
+
+/**
+ * Enqueues a task on the Event Queue that must be invoked later.
+ *
+ * Example of usage:
+ * ```
+ * onEvent.enqueue { myDialog.isVisible = true }
+ * ```
+ * @param owner is the owner of the event handler, typically `this` instance.
+ * @param callable is used for providing the event handler function.
+ */
+fun <T> Event<T>.enqueue(owner: Any, callable: () -> Unit) {
+    this.subscribe(owner) { EDT.enqueue { callable.invoke() } }
 }

--- a/gui-app/src/test/kotlin/dev/robocode/tankroyale/gui/util/EventTest.kt
+++ b/gui-app/src/test/kotlin/dev/robocode/tankroyale/gui/util/EventTest.kt
@@ -1,12 +1,10 @@
 package dev.robocode.tankroyale.gui.util
 
+import dev.robocode.tankroyale.client.Event
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.lang.ref.WeakReference
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -14,52 +12,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class EventTest : FunSpec({
 
     context("Event class") {
-
-        test("subscribe and fire") {
-            val event = Event<String>()
-            val result = mutableListOf<String>()
-
-            event.subscribe(this) { result.add(it) }
-            event.fire("test")
-
-            result shouldBe listOf("test")
-        }
-
-        test("unsubscribe") {
-            val event = Event<String>()
-            val result = mutableListOf<String>()
-
-            event.subscribe(this) { result.add(it) }
-            event.fire("test1")
-            event.unsubscribe(this)
-            event.fire("test2")
-
-            result shouldBe listOf("test1")
-        }
-
-        test("subscribe once") {
-            val event = Event<String>()
-            val result = mutableListOf<String>()
-
-            event.subscribe(this, once = true) { result.add(it) }
-            event.fire("test1")
-            event.fire("test2")
-
-            result shouldBe listOf("test1")
-        }
-
-        test("multiple subscribers") {
-            val event = Event<String>()
-            val result1 = mutableListOf<String>()
-            val result2 = mutableListOf<String>()
-
-            event.subscribe("subscriber1") { result1.add(it) }
-            event.subscribe("subscriber2") { result2.add(it) }
-            event.fire("test")
-
-            result1 shouldBe listOf("test")
-            result2 shouldBe listOf("test")
-        }
 
         test("enqueue") {
             val event = Event<Unit>()
@@ -78,70 +30,6 @@ class EventTest : FunSpec({
             }
 
             counter.get() shouldBe 1
-        }
-
-        test("Handler class") {
-            val handler = Event.Handler<String>({ }, true)
-
-            handler.shouldBeInstanceOf<Event.Handler<String>>()
-            handler.once shouldBe true
-        }
-
-        test("subscriber is removed when owner is garbage collected") {
-            val event = Event<String>()
-            val result = AtomicInteger(0)
-
-            class Subscriber {
-                fun handleEvent(msg: String) {
-                    result.incrementAndGet()
-                }
-            }
-
-            var subscriber: Subscriber? = Subscriber()
-            val weakRef = WeakReference(subscriber)
-
-            event.subscribe(subscriber!!) { msg ->
-                weakRef.get()?.handleEvent(msg)
-            }
-
-            // Verify that the subscriber is initially present
-            event.fire("test")
-            result.get() shouldBe 1
-
-            // Remove strong reference to subscriber and force garbage collection
-            subscriber = null
-            System.gc()
-            Thread.sleep(100)
-
-            // Fire the event again
-            event.fire("test")
-
-            // The result should still be 1 because the subscriber should have been removed
-            result.get() shouldBe 1
-
-            // Verify that the eventHandlers map is empty
-            val eventHandlersField = Event::class.java.getDeclaredField("eventHandlers")
-            eventHandlersField.isAccessible = true
-            val eventHandlers = eventHandlersField.get(event) as Map<*, *>
-            eventHandlers.shouldBeEmpty()
-        }
-
-        test("subscriber reference type") {
-            val event = Event<String>()
-            val subscriber = object : Any() {}
-
-            event.subscribe(subscriber) { }
-
-            // Use reflection to access the private eventHandlers field
-            val eventHandlersField = Event::class.java.getDeclaredField("eventHandlers")
-            eventHandlersField.isAccessible = true
-            val eventHandlers = eventHandlersField.get(event) as Map<*, *>
-
-            // Check that the value in the eventHandlers map is our Handler class
-            eventHandlers.values.first().shouldBeInstanceOf<Event.Handler<String>>()
-
-            // Check that the key in the eventHandlers map is our subscriber object
-            eventHandlers.keys.first() shouldBe subscriber
         }
     }
 })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,9 @@ rootProject.name = "robocode-tank-royale"
 
 val version: String = providers.gradleProperty("version").get()
 
+// Lib
+include("client-lib")
+
 // Booter
 include("booter")
 


### PR DESCRIPTION
Extract client-related logic from gui-app to a separate subproject so that other/future components (e.g. recorder) can reuse the code.