### PR TITLE
Ported `TrackAndFire` and `VelocityBot` to Python. Made small change to how we track remaining turn angle. Fixed some bugs.

### DIFF
--- a/bot-api/python/src/robocode_tank_royale/bot_api/base_bot.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/base_bot.py
@@ -176,11 +176,11 @@ class BaseBot(BaseBotABC):
 
     @property
     def max_turn_rate(self) -> float:
-        return self._internals.max_turn_rate
+        return self._internals.get_max_turn_rate()
 
     @max_turn_rate.setter
     def max_turn_rate(self, max_turn_rate: float) -> None:
-        self._internals.max_turn_rate = max_turn_rate
+        self._internals.set_max_turn_rate(max_turn_rate)
 
     @property
     def gun_turn_rate(self) -> float:
@@ -192,11 +192,11 @@ class BaseBot(BaseBotABC):
 
     @property
     def max_gun_turn_rate(self) -> float:
-        return self._internals.max_gun_turn_rate
+        return self._internals.get_max_gun_turn_rate()
 
     @max_gun_turn_rate.setter
     def max_gun_turn_rate(self, max_gun_turn_rate: float) -> None:
-        self._internals.max_gun_turn_rate = max_gun_turn_rate
+        self._internals.set_max_gun_turn_rate(max_gun_turn_rate)
 
     @property
     def radar_turn_rate(self) -> float:
@@ -208,11 +208,11 @@ class BaseBot(BaseBotABC):
 
     @property
     def max_radar_turn_rate(self) -> float:
-        return self._internals.max_radar_turn_rate
+        return self._internals.get_max_radar_turn_rate()
 
     @max_radar_turn_rate.setter
     def max_radar_turn_rate(self, max_radar_turn_rate: float) -> None:
-        self._internals.max_radar_turn_rate = max_radar_turn_rate
+        self._internals.set_max_radar_turn_rate(max_radar_turn_rate)
 
     @property
     def target_speed(self) -> float:
@@ -227,11 +227,11 @@ class BaseBot(BaseBotABC):
 
     @property
     def max_speed(self) -> float:
-        return self._internals.max_speed
+        return self._internals.get_max_speed()
 
     @max_speed.setter
     def max_speed(self, max_speed: float) -> None:
-        self._internals.max_speed = max_speed
+        self._internals.set_max_speed(max_speed)
 
     def set_fire(self, firepower: float) -> bool:
         return self._internals.set_fire(firepower)

--- a/bot-api/python/src/robocode_tank_royale/bot_api/bot.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/bot.py
@@ -21,8 +21,10 @@ class _BotInternals(StopResumeListenerABC):
         self._clear_remaining()
 
         handlers = self._base_bot_internals.internal_event_handlers
+
         async def _stop_thread(_: ...) -> None:
             self._base_bot_internals.stop_thread()
+
         handlers.on_game_aborted.subscribe(_stop_thread, 100)
         handlers.on_round_ended.subscribe(_stop_thread, 90)
         handlers.on_game_ended.subscribe(_stop_thread, 90)
@@ -58,18 +60,18 @@ class _BotInternals(StopResumeListenerABC):
 
     def _clear_remaining(self) -> None:
         """Clear the remaining movement and turn values."""
-        self.distance_remaining: float = 0.
-        self.turn_remaining: float = 0.
-        self.gun_turn_remaining: float = 0.
-        self.radar_turn_remaining: float = 0.
+        self.distance_remaining: float = 0.0
+        self.turn_remaining: float = 0.0
+        self.gun_turn_remaining: float = 0.0
+        self.radar_turn_remaining: float = 0.0
         try:
             self._previous_direction: float = self._bot.get_direction()
             self._previous_gun_direction: float = self._bot.get_gun_direction()
             self._previous_radar_direction: float = self._bot.get_radar_direction()
         except Exception:
-            self._previous_direction = 0.
-            self._previous_gun_direction = 0.
-            self._previous_radar_direction = 0.
+            self._previous_direction = 0.0
+            self._previous_gun_direction = 0.0
+            self._previous_radar_direction = 0.0
 
     def _process_turn(self) -> None:
         """Process the bot's turn, updating movement and turn values."""
@@ -82,51 +84,65 @@ class _BotInternals(StopResumeListenerABC):
         self._update_radar_turn_remaining()
 
     async def on_hit_wall(self):
-        self.distance_remaining = 0.
+        self.distance_remaining = 0.0
 
     async def on_hit_bot(self, e: HitBotEvent) -> None:
         if e.is_rammed:
-            self.distance_remaining = 0.
+            self.distance_remaining = 0.0
 
     @property
     def turn_rate(self) -> float:
         return self._base_bot_internals.turn_rate
+
     @turn_rate.setter
     def turn_rate(self, x: float) -> None:
         self._override_turn_rate = False
-        self.turn_remaining = self._to_infinite_value(self._base_bot_internals.turn_rate)
+        self.turn_remaining = self._to_infinite_value(
+            self._base_bot_internals.turn_rate
+        )
         self._base_bot_internals.turn_rate = x
 
     @property
     def gun_turn_rate(self) -> float:
         return self._base_bot_internals.gun_turn_rate
+
     @gun_turn_rate.setter
     def gun_turn_rate(self, x: float) -> None:
         self._override_gun_turn_rate = False
-        self.gun_turn_remaining = self._to_infinite_value(self._base_bot_internals.gun_turn_rate)
+        self.gun_turn_remaining = self._to_infinite_value(
+            self._base_bot_internals.gun_turn_rate
+        )
         self._base_bot_internals.gun_turn_rate = x
 
     @property
     def radar_turn_rate(self) -> float:
         return self._base_bot_internals.radar_turn_rate
+
     @radar_turn_rate.setter
     def radar_turn_rate(self, x: float) -> None:
         self._override_radar_turn_rate = False
-        self.radar_turn_remaining = self._to_infinite_value(self._base_bot_internals.radar_turn_rate)
+        self.radar_turn_remaining = self._to_infinite_value(
+            self._base_bot_internals.radar_turn_rate
+        )
         self._base_bot_internals.radar_turn_rate = x
 
     def _to_infinite_value(self, x: float) -> float:
         """Convert a turn rate to an infinite value for remaining turns."""
         if x > 0:
-            return float('inf')
+            return float("inf")
         elif x < 0:
-            return float('-inf')
+            return float("-inf")
         return 0.0
 
-    def set_target_speed(self, speed: float) -> None:
+    @property
+    def target_speed(self) -> float | None:
+        return self._base_bot_internals.target_speed
+
+    @target_speed.setter
+    def target_speed(self, speed: float) -> None:
         self._override_target_speed = False
         self.distance_remaining = self._to_infinite_value(speed)
-        self._base_bot_internals.set_target_speed(speed)
+        self._base_bot_internals.target_speed = speed
 
     def set_forward(self, distance: float) -> None:
         self._override_target_speed = True
@@ -140,7 +156,9 @@ class _BotInternals(StopResumeListenerABC):
             await self._bot.go()
         else:
             self.set_forward(distance)
-            await self.wait_for(lambda: self.distance_remaining == 0. and self._bot.get_speed() == 0.)
+            await self.wait_for(
+                lambda: self.distance_remaining == 0.0 and self._bot.get_speed() == 0.0
+            )
 
     def set_turn_left(self, degrees: float) -> None:
         self._override_turn_rate = True
@@ -189,7 +207,7 @@ class _BotInternals(StopResumeListenerABC):
 
     async def wait_for(self, condition: Callable[[], bool]) -> None:
         await self._bot.go()
-        while (self._base_bot_internals.is_running() and not condition()):
+        while self._base_bot_internals.is_running() and not condition():
             await self._bot.go()
 
     async def stop(self, overwrite: bool) -> None:
@@ -222,52 +240,50 @@ class _BotInternals(StopResumeListenerABC):
 
     def _update_turn_remaining(self) -> None:
         """Update the turn remaining value based on the bot's current direction."""
-        delta = self._bot.calc_delta_angle(self._bot.get_direction(), self._previous_direction)
+        delta = self._bot.calc_delta_angle(
+            self._bot.get_direction(), self._previous_direction
+        )
         self._previous_direction = self._bot.get_direction()
 
         if not self._override_turn_rate:
             # called after a previous direction has been calculated and stored!
             return
-        if abs(self.turn_remaining) <= abs(delta):
+
+        self.turn_remaining -= delta
+        if self._is_near_zero(self.turn_remaining):
             self.turn_remaining = 0
-        else:
-            self.turn_remaining -= delta
-            if self._is_near_zero(self.turn_remaining):
-                self.turn_remaining = 0
 
         self._base_bot_internals.turn_rate = self.turn_remaining
 
     def _update_gun_turn_remaining(self) -> None:
         """Update the gun turn remaining value based on the bot's current gun direction."""
-        delta = self._bot.calc_delta_angle(self._bot.get_gun_direction(), self._previous_gun_direction)
+        delta = self._bot.calc_delta_angle(
+            self._bot.get_gun_direction(), self._previous_gun_direction
+        )
         self._previous_gun_direction = self._bot.get_gun_direction()
 
         if not self._override_gun_turn_rate:
             return
 
-        if abs(self.gun_turn_remaining) <= abs(delta):
+        self.gun_turn_remaining -= delta
+        if self._is_near_zero(self.gun_turn_remaining):
             self.gun_turn_remaining = 0
-        else:
-            self.gun_turn_remaining -= delta
-            if self._is_near_zero(self.gun_turn_remaining):
-                self.gun_turn_remaining = 0
 
         self._base_bot_internals.gun_turn_rate = self.gun_turn_remaining
 
     def _update_radar_turn_remaining(self) -> None:
         """Update the radar turn remaining value based on the bot's current radar direction."""
-        delta = self._bot.calc_delta_angle(self._bot.get_radar_direction(), self._previous_radar_direction)
+        delta = self._bot.calc_delta_angle(
+            self._bot.get_radar_direction(), self._previous_radar_direction
+        )
         self._previous_radar_direction = self._bot.get_radar_direction()
 
         if not self._override_radar_turn_rate:
             return
 
-        if abs(self.radar_turn_remaining) <= abs(delta):
+        self.radar_turn_remaining -= delta
+        if self._is_near_zero(self.radar_turn_remaining):
             self.radar_turn_remaining = 0
-        else:
-            self.radar_turn_remaining -= delta
-            if self._is_near_zero(self.radar_turn_remaining):
-                self.radar_turn_remaining = 0
 
         self._base_bot_internals.radar_turn_rate = self.radar_turn_remaining
 
@@ -278,7 +294,9 @@ class _BotInternals(StopResumeListenerABC):
             else:
                 self.distance_remaining -= self._bot.get_speed()
         elif math.isinf(self.distance_remaining):
-            self._base_bot_internals.set_target_speed(MAX_SPEED if self.distance_remaining > 0 else -MAX_SPEED)
+            self._base_bot_internals.target_speed = (
+                MAX_SPEED if self.distance_remaining > 0 else -MAX_SPEED
+            )
         else:
             distance = self.distance_remaining
             # This is Nat Pavasant's method described here:
@@ -291,14 +309,19 @@ class _BotInternals(StopResumeListenerABC):
             self.distance_remaining = distance - new_speed
             # the overdrive flag
             if distance * new_speed >= 0:
-                self._is_over_driving = self._base_bot_internals.get_distance_traveled_until_stop(new_speed) > abs(distance)
+                self._is_over_driving = (
+                    self._base_bot_internals.get_distance_traveled_until_stop(new_speed)
+                    > abs(distance)
+                )
 
             self.distance_remaining = distance - new_speed
 
     def _get_and_set_new_target_speed(self, distance: float) -> float:
         """Get and set the new target speed based on the remaining distance."""
-        speed = self._base_bot_internals.get_new_target_speed(self._bot.get_speed(), distance)
-        self._base_bot_internals.set_target_speed(speed)
+        speed = self._base_bot_internals.get_new_target_speed(
+            self._bot.get_speed(), distance
+        )
+        self._base_bot_internals.target_speed = speed
         return speed
 
     def _is_near_zero(self, x: float) -> bool:
@@ -313,10 +336,16 @@ class Bot(BaseBot, BotABC):
     abstract methods that must be overridden by any specific bot implementation.
     """
 
-
-    def __init__(self, bot_info: None|BotInfo = None, server_url: None|str = None, server_secret: None|str = None):
+    def __init__(
+        self,
+        bot_info: None | BotInfo = None,
+        server_url: None | str = None,
+        server_secret: None | str = None,
+    ):
         super().__init__(bot_info, server_url, server_secret)
-        self._bot_internals = _BotInternals(bot=self, base_bot_internals=self._internals)
+        self._bot_internals = _BotInternals(
+            bot=self, base_bot_internals=self._internals
+        )
 
     async def run(self) -> None:
         """Main method to run the bot's logic."""
@@ -330,94 +359,107 @@ class Bot(BaseBot, BotABC):
     def turn_rate(self) -> float:
         """Get the turn rate of the bot."""
         return self._bot_internals.turn_rate
+
     @turn_rate.setter
     def turn_rate(self, turn_rate: float) -> None:
         """Set the turn rate of the bot."""
         self._bot_internals.turn_rate = turn_rate
-    
+
     @property
     def gun_turn_rate(self) -> float:
-       return self._bot_internals.gun_turn_rate
+        return self._bot_internals.gun_turn_rate
+
     @gun_turn_rate.setter
     def gun_turn_rate(self, gun_turn_rate: float) -> None:
         self._bot_internals.gun_turn_rate = gun_turn_rate
-    
+
     @property
     def radar_turn_rate(self) -> float:
         return self._bot_internals.radar_turn_rate
+
     @radar_turn_rate.setter
     def radar_turn_rate(self, radar_turn_rate: float) -> None:
         self._bot_internals.radar_turn_rate = radar_turn_rate
-    
+
     def is_running(self) -> bool:
         """Check if the bot is currently running."""
         return self._internals.is_running()
-    
-    def set_target_speed(self, target_speed: float) -> None:
-       self._bot_internals.set_target_speed(target_speed)
 
     def set_forward(self, distance: float) -> None:
         self._bot_internals.set_forward(distance)
+
     async def forward(self, distance: float) -> None:
         await self._bot_internals.forward(distance)
+
     def set_back(self, distance: float) -> None:
         self.set_forward(-distance)
+
     async def back(self, distance: float) -> None:
         await self.forward(-distance)
-    
+
     @property
     def distance_remaining(self) -> float:
-       return self._bot_internals.distance_remaining
-    
+        return self._bot_internals.distance_remaining
+
     def set_turn_left(self, degrees: float) -> None:
         self._bot_internals.set_turn_left(degrees)
+
     async def turn_left(self, degrees: float) -> None:
         await self._bot_internals.turn_left(degrees)
+
     def set_turn_right(self, degrees: float) -> None:
-       self.set_turn_left(-degrees)
+        self.set_turn_left(-degrees)
+
     async def turn_right(self, degrees: float) -> None:
         await self.turn_left(-degrees)
-    
+
     @property
     def turn_remaining(self) -> float:
         return self._bot_internals.turn_remaining
-    
+
     def set_turn_gun_left(self, degrees: float) -> None:
         self._bot_internals.set_turn_gun_left(degrees)
+
     async def turn_gun_left(self, degrees: float) -> None:
         await self._bot_internals.turn_gun_left(degrees)
+
     def set_turn_gun_right(self, degrees: float) -> None:
         self.set_turn_gun_left(-degrees)
+
     async def turn_gun_right(self, degrees: float) -> None:
         await self.turn_gun_left(-degrees)
 
     @property
     def gun_turn_remaining(self) -> float:
         return self._bot_internals.gun_turn_remaining
-    
+
     def set_turn_radar_left(self, degrees: float) -> None:
         self._bot_internals.set_turn_radar_left(degrees)
+
     async def turn_radar_left(self, degrees: float) -> None:
         await self._bot_internals.turn_radar_left(degrees)
+
     def set_turn_radar_right(self, degrees: float) -> None:
         self.set_turn_radar_left(-degrees)
+
     async def turn_radar_right(self, degrees: float) -> None:
         await self.turn_radar_left(-degrees)
-    
+
     @property
     def radar_turn_remaining(self) -> float:
         return self._bot_internals.radar_turn_remaining
-    
+
     async def fire(self, firepower: float) -> None:
         await self._bot_internals.fire(firepower)
-    
+
     async def stop(self, overwrite: bool = False) -> None:
         await self._bot_internals.stop(overwrite)
+
     async def resume(self) -> None:
         await self._bot_internals.resume()
 
     async def rescan(self) -> None:
         await self._bot_internals.rescan()
-    
+
     async def wait_for(self, condition: Callable[[], bool]) -> None:
         await self._bot_internals.wait_for(condition)

--- a/bot-api/python/src/robocode_tank_royale/bot_api/color.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/color.py
@@ -63,7 +63,7 @@ class Color:
 
         Args:
             red (int): The red component of the color (0–255).
-            green (int): The green component of the color (0–255).
+            green (int): The green componen8t of the color (0–255).
             blue (int): The blue component of the color (0–255).
             alpha (int): The alpha (transparency) component of the color (0–255).
 
@@ -123,6 +123,9 @@ class Color:
         Returns:
             schema.Color: A schema.Color instance with the same RGB and alpha values.
         """
-        return ColorSchema(
-            value=f"#{self.red:02x}{self.green:02x}{self.blue:02x}{self.alpha:02x}"
-        )
+        if self.alpha == 255:
+            return ColorSchema(value=f"#{self.red:02x}{self.green:02x}{self.blue:02x}")
+        else:
+            return ColorSchema(
+                value=f"#{self.red:02x}{self.green:02x}{self.blue:02x}{self.alpha:02x}"
+            )

--- a/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
@@ -407,7 +407,7 @@ class BaseBotInternals:
                     == asyncio.current_task()  # Ensure this is the bot's main task\
                     and not asyncio.current_task().cancelled()  # type: ignore
                 ):
-                        await self.next_turn_monitor.wait()
+                    await self.next_turn_monitor.wait()
         except asyncio.CancelledError:
             # We get a CancelledError if the server stops the game.
             return None
@@ -490,49 +490,48 @@ class BaseBotInternals:
             radar_turn_rate, -self.max_radar_turn_rate, self.max_radar_turn_rate
         )
 
-    def set_target_speed(self, target_speed: float) -> None:
+    @property
+    def target_speed(self) -> float | None:
+        return self.data.bot_intent.target_speed
+
+    @target_speed.setter
+    def target_speed(self, target_speed: float) -> None:
         if math.isnan(target_speed):
             raise ValueError("'target_speed' cannot be NaN")
         self.data.bot_intent.target_speed = MathUtil.clamp(
             target_speed, -self.max_speed, self.max_speed
         )
 
-    def get_max_speed(
-        self,
-    ) -> float:  # Max speed is part of bot's own limits, not server state
+    def get_max_speed(self) -> float:
+        # Max speed is part of bot's own limits, not server state
         return self.max_speed
 
-    def set_max_speed(
-        self, max_speed: float
-    ) -> None:  # Max speed is part of bot's own limits
+    def set_max_speed(self, max_speed: float) -> None:
+        # Max speed is part of bot's own limits
         self.max_speed = MathUtil.clamp(max_speed, 0, MAX_SPEED)
 
-    def get_max_turn_rate(self) -> float:  # Max turn rate is part of bot's own limits
+    def get_max_turn_rate(self) -> float:
+        # Max turn rate is part of bot's own limits
         return self.max_turn_rate
 
-    def set_max_turn_rate(
-        self, max_turn_rate: float
-    ) -> None:  # Max turn rate is part of bot's own limits
+    def set_max_turn_rate(self, max_turn_rate: float) -> None:
+        # Max turn rate is part of bot's own limits
         self.max_turn_rate = MathUtil.clamp(max_turn_rate, 0, MAX_TURN_RATE)
 
-    def get_max_gun_turn_rate(
-        self,
-    ) -> float:  # Max gun turn rate is part of bot's own limits
+    def get_max_gun_turn_rate(self) -> float:
+        # Max gun turn rate is part of bot's own limits
         return self.max_gun_turn_rate
 
-    def set_max_gun_turn_rate(
-        self, max_gun_turn_rate: float
-    ) -> None:  # Max gun turn rate is part of bot's own limits
+    def set_max_gun_turn_rate(self, max_gun_turn_rate: float) -> None:
+        # Max gun turn rate is part of bot's own limits
         self.max_gun_turn_rate = MathUtil.clamp(max_gun_turn_rate, 0, MAX_GUN_TURN_RATE)
 
-    def get_max_radar_turn_rate(
-        self,
-    ) -> float:  # Max radar turn rate is part of bot's own limits
+    def get_max_radar_turn_rate(self) -> float:
+        # Max radar turn rate is part of bot's own limits
         return self.max_radar_turn_rate
 
-    def set_max_radar_turn_rate(
-        self, max_radar_turn_rate: float
-    ) -> None:  # Max radar turn rate is part of bot's own limits
+    def set_max_radar_turn_rate(self, max_radar_turn_rate: float) -> None:
+        # Max radar turn rate is part of bot's own limits
         self.max_radar_turn_rate = MathUtil.clamp(
             max_radar_turn_rate, 0, MAX_RADAR_TURN_RATE
         )

--- a/sample-bots/python/Crazy/Crazy.py
+++ b/sample-bots/python/Crazy/Crazy.py
@@ -26,11 +26,11 @@ class Crazy(ba.Bot):
         self._moving_forward = False
 
     async def run(self) -> None:
-        # self.body_color = ba.Color.from_rgb(0x00, 0xC8, 0x00)  # lime
-        # self.turrent_color = ba.Color.from_rgb(0x00, 0x96, 0x32)  # green
-        # self.radar_color = ba.Color.from_rgb(0x00, 0x64, 0x64)  # dark cyan
-        # self.bullet_color = ba.Color.from_rgb(0xFF, 0xFF, 0x64)  # yellow
-        # self.scan_color = ba.Color.from_rgb(0xFF, 0xC8, 0xC8)  # light red
+        self.body_color = ba.Color.from_rgb(0x00, 0xC8, 0x00)  # lime
+        self.turrent_color = ba.Color.from_rgb(0x00, 0x96, 0x32)  # green
+        self.radar_color = ba.Color.from_rgb(0x00, 0x64, 0x64)  # dark cyan
+        self.bullet_color = ba.Color.from_rgb(0xFF, 0xFF, 0x64)  # yellow
+        self.scan_color = ba.Color.from_rgb(0xFF, 0xC8, 0xC8)  # light red
 
         while self.is_running():
             # Tell the game we will want to move ahead 40000 -- some large number

--- a/sample-bots/python/MyFirstBot/MyFirstBot.py
+++ b/sample-bots/python/MyFirstBot/MyFirstBot.py
@@ -21,7 +21,10 @@ class MyFirstBot(ba.Bot):
 
     async def on_hit_by_bullet(self, hit_by_bullet_event: HitByBulletEvent) -> None:
         bearing = self.calc_bearing(hit_by_bullet_event.bullet.direction)
-        await self.turn_right(90 - bearing)
+        turn_angle = 90 - bearing
+        if turn_angle > 180:
+            turn_angle -= 180
+        await self.turn_right(turn_angle)
 
 async def main():
     b = MyFirstBot()

--- a/sample-bots/python/TrackFire/TrackFire.json
+++ b/sample-bots/python/TrackFire/TrackFire.json
@@ -1,0 +1,16 @@
+{
+  "name": "Track Fire",
+  "version": "1.0",
+  "authors": [
+    "Mathew Nelson",
+    "Flemming N. Larsen"
+  ],
+  "description": "Sits still. Tracks and fires at the nearest bot it sees.",
+  "homepage": "",
+  "country_codes": [
+    "us",
+    "dk"
+  ],
+  "platform": "Python",
+  "programming_lang": "Python"
+}

--- a/sample-bots/python/TrackFire/TrackFire.py
+++ b/sample-bots/python/TrackFire/TrackFire.py
@@ -1,0 +1,46 @@
+import asyncio
+from robocode_tank_royale.bot_api.bot import Bot
+from robocode_tank_royale.bot_api.events import ScannedBotEvent, WonRoundEvent
+from robocode_tank_royale.bot_api.color import Color
+
+
+class TrackFire(Bot):
+    """
+    A sample bot that sits still while tracking and firing at the nearest bot it detects.
+    """
+
+    async def run(self):
+        """Main method"""
+        pink = Color.from_rgb(0xFF, 0x69, 0xB4)
+        self.body_color = pink
+        self.turret_color = pink
+        self.radar_color = pink
+        self.scan_color = pink
+        self.bullet_color = pink
+
+        while self.is_running():
+            await self.turn_gun_right(10)
+
+    async def on_scanned_bot(self, scanned_bot_event: ScannedBotEvent) -> None:
+        """Event handler for scanned bot"""
+        bearing_from_gun = self.gun_bearing_to(scanned_bot_event.x, scanned_bot_event.y)
+        self.set_turn_gun_left(bearing_from_gun)
+
+        if abs(bearing_from_gun) <= 3 and self.get_gun_heat() == 0:
+            self.set_fire(min(3 - abs(bearing_from_gun), self.get_energy() - 0.1))
+
+        await self.rescan()
+
+    async def on_won_round(self, won_round_event: WonRoundEvent) -> None:
+        """Event handler for winning a round"""
+        await self.turn_right(36_000)
+
+
+async def main():
+    """Main method"""
+    bot = TrackFire()
+    await bot.start()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sample-bots/python/VelocityBot/VelocityBot.json
+++ b/sample-bots/python/VelocityBot/VelocityBot.json
@@ -1,0 +1,12 @@
+{
+  "name": "Velocity Bot",
+  "version": "1.0",
+  "authors": [
+    "Joshua Galecki"
+  ],
+  "description": "Example bot of how to use turn rates.",
+  "homepage": "",
+  "country_codes": [],
+  "platform": "Python",
+  "programming_lang": "Python"
+}

--- a/sample-bots/python/VelocityBot/VelocityBot.py
+++ b/sample-bots/python/VelocityBot/VelocityBot.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from robocode_tank_royale.bot_api import Bot
+from robocode_tank_royale.bot_api import events
+
+class VelocityBot(Bot):
+    turn_counter: int
+
+    async def run(self) -> None:
+        self.turn_counter = 0
+        self.gun_turn_rate = 15
+
+        while self.is_running():
+            if self.turn_counter % 64 == 0:
+                self.turn_rate = 0
+                self.target_speed = 4
+            
+            if self.turn_counter % 64 == 32:
+                self.target_speed = -6
+            
+            self.turn_counter += 1
+            await self.go()
+
+    async def on_scanned_bot(self, scanned_bot_event: events.ScannedBotEvent) -> None:
+        await self.fire(1)
+
+    async def on_hit_by_bullet(self, hit_by_bullet_event: events.HitByBulletEvent) -> None:
+        self.turn_rate = 5
+
+    async def on_hit_wall(self, bot_hit_wall_event: events.HitWallEvent) -> None:
+        assert self.target_speed is not None
+        self.target_speed = -1 * self.target_speed
+
+
+async def main():
+    """Main method"""
+    bot = VelocityBot()
+    await bot.start()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- The current way to track remaining turn angle is a bit weird to me, specifically I don't know why we clear out the remaining turn angle if it is smaller than the current delta (this angle - last angle).
  - This is a problem when the remaining turn angle gets updated through a `set.*turn` call while a previous turn is being executed, and causes the second call to be completely skipped when the previous turn is faster.
  - This causes the `TrackAndFire` bot to track poorly in both Java and Python. I notice that w/o zeroing out the remaining turn, `TrackAndFire` tracks really well and rarely loses track once locked on.

- Ported `TrackFire` and `VelocityBot` sample bots to python.
  - Getting to the point where Gemini can do this pretty easily since we have a few examples.

- Fix bug w/ color schema serialization; the server side does not support the alpha channel.
  - Adding back the color specifications of some sample bots.

- Fix APIs for a few functions that had trouble with the original Java -> Python porting; some should have been converted to python properties but did not.

- Formatting improvements.