### PR TITLE
Add replay timeline and allow seeking

### DIFF
--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
@@ -11,6 +11,7 @@ import dev.robocode.tankroyale.gui.client.ClientEvents.onGameStarted
 import dev.robocode.tankroyale.gui.client.ClientEvents.onPlayerChanged
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundEnded
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundStarted
+import dev.robocode.tankroyale.gui.client.ClientEvents.onSeekToTurn
 import dev.robocode.tankroyale.gui.client.ClientEvents.onStdOutputUpdated
 import dev.robocode.tankroyale.gui.client.ClientEvents.onTickEvent
 import dev.robocode.tankroyale.gui.player.BattlePlayer
@@ -138,6 +139,7 @@ object Client {
         player.onTickEvent.subscribe(Client) { onTickEvent.fire(it) }
         player.onBotListUpdate.subscribe(Client) { onBotListUpdate.fire(it) }
         player.onStdOutputUpdated.subscribe(Client) { onStdOutputUpdated.fire(it) }
+        player.onSeekToTurn.subscribe(Client) { onSeekToTurn.fire(it) }
     }
 
     private fun unsubscribeFromPlayerEvents(player: BattlePlayer) {
@@ -152,5 +154,6 @@ object Client {
         player.onTickEvent.unsubscribe(Client)
         player.onBotListUpdate.unsubscribe(Client)
         player.onStdOutputUpdated.unsubscribe(Client)
+        player.onSeekToTurn.unsubscribe(Client)
     }
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/Client.kt
@@ -8,6 +8,7 @@ import dev.robocode.tankroyale.gui.client.ClientEvents.onGameEnded
 import dev.robocode.tankroyale.gui.client.ClientEvents.onGamePaused
 import dev.robocode.tankroyale.gui.client.ClientEvents.onGameResumed
 import dev.robocode.tankroyale.gui.client.ClientEvents.onGameStarted
+import dev.robocode.tankroyale.gui.client.ClientEvents.onPlayerChanged
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundEnded
 import dev.robocode.tankroyale.gui.client.ClientEvents.onRoundStarted
 import dev.robocode.tankroyale.gui.client.ClientEvents.onStdOutputUpdated
@@ -61,8 +62,9 @@ object Client {
         currentPlayer = player
         subscribeToPlayerEvents(player)
         player.start()
-        // Initialize player with current TPS setting
-        //player.changeTps(ConfigSettings.tps)
+
+        // Fire event that player has changed
+        onPlayerChanged.fire(player)
     }
 
     fun isLivePlayerConnected(): Boolean =

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
@@ -21,4 +21,7 @@ object ClientEvents {
 
     /** Fired when the active battle player changes */
     val onPlayerChanged = Event<BattlePlayer>()
+
+    /** Fired when the user seeks to a specific position when replaying a battle */
+    val onSeekToTurn = Event<TickEvent>()
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/client/ClientEvents.kt
@@ -2,6 +2,7 @@ package dev.robocode.tankroyale.gui.client
 
 import dev.robocode.tankroyale.client.model.*
 import dev.robocode.tankroyale.common.Event
+import dev.robocode.tankroyale.gui.player.BattlePlayer
 
 object ClientEvents {
     val onConnected = Event<Unit>()
@@ -17,4 +18,7 @@ object ClientEvents {
 
     val onStdOutputUpdated = Event<TickEvent>()
     val onBotPolicyChanged = Event<BotPolicyUpdate>()
+
+    /** Fired when the active battle player changes */
+    val onPlayerChanged = Event<BattlePlayer>()
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattleInfo.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattleInfo.kt
@@ -1,0 +1,10 @@
+package dev.robocode.tankroyale.gui.player
+
+/**
+ * Contains information about a battle replay that is useful for UI components like progress sliders.
+ * This data is provided when a battle player loads a replay file.
+ */
+data class BattleInfo(
+    /** Total number of turns in the battle */
+    val totalEvents: Int,
+)

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattlePlayer.kt
@@ -10,16 +10,6 @@ import dev.robocode.tankroyale.common.Event
 interface BattlePlayer {
 
     /**
-     * Returns the set of features supported by this battle player.
-     */
-    fun getSupportedFeatures(): Set<BattlePlayerFeature>
-
-    /**
-     * Checks if a specific feature is supported by this player.
-     */
-    fun supportsFeature(feature: BattlePlayerFeature): Boolean = feature in getSupportedFeatures()
-
-    /**
      * Starts the battle. For live players, this connects to server and starts game.
      * For replay players, this begins playback from the beginning.
      */
@@ -49,13 +39,6 @@ interface BattlePlayer {
      * Restarts the current battle.
      */
     fun restart()
-
-    /**
-     * Seeks to a specific turn in the battle (if supported).
-     * @param turnNumber The turn number to seek to
-     * @throws UnsupportedOperationException if SEEK feature is not supported
-     */
-    fun seekToTurn(turnNumber: Int)
 
     /**
      * Returns true if the battle is currently running.

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/BattlePlayer.kt
@@ -141,4 +141,7 @@ interface BattlePlayer {
 
     /** Fired when standard output is updated */
     val onStdOutputUpdated: Event<TickEvent>
+
+    /** Fired when the user seeks to a specific position when replaying a battle */
+    val onSeekToTurn: Event<TickEvent>
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/LiveBattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/LiveBattlePlayer.kt
@@ -68,10 +68,6 @@ class LiveBattlePlayer : BattlePlayer {
         }
     }
 
-    override fun getSupportedFeatures(): Set<BattlePlayerFeature> {
-        return setOf()
-    }
-
     override fun start() {
         connect()
     }
@@ -129,10 +125,6 @@ class LiveBattlePlayer : BattlePlayer {
         } else {
             startWithLastGameSetup()
         }
-    }
-
-    override fun seekToTurn(turnNumber: Int) {
-        throw UnsupportedOperationException("SEEK feature not supported by live battle player")
     }
 
     override fun isRunning(): Boolean = isRunning.get()

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/LiveBattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/LiveBattlePlayer.kt
@@ -57,6 +57,7 @@ class LiveBattlePlayer : BattlePlayer {
     override val onTickEvent = Event<TickEvent>()
     override val onBotListUpdate = Event<BotListUpdate>()
     override val onStdOutputUpdated = Event<TickEvent>()
+    override val onSeekToTurn = Event<TickEvent>()
 
     init {
         ServerEvents.onStopped.subscribe(this) {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
@@ -91,10 +91,6 @@ class ReplayBattlePlayer(private val replayFile: File) : BattlePlayer {
         }
         .map { (i, turn) -> i to turn.any { it is RoundEndedEvent } }
 
-    override fun getSupportedFeatures(): Set<BattlePlayerFeature> {
-        return setOf(BattlePlayerFeature.SEEK)
-    }
-
     override fun start() {
         if (isRunning.get()) {
             stop()
@@ -156,7 +152,7 @@ class ReplayBattlePlayer(private val replayFile: File) : BattlePlayer {
         start()
     }
 
-    override fun seekToTurn(turnNumber: Int) {
+    fun seekToTurn(turnNumber: Int) {
         val wasRunning = isRunning.get()
         val wasPaused = isPaused.get()
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
@@ -79,14 +79,17 @@ class ReplayBattlePlayer(private val replayFile: File) : BattlePlayer {
 
     fun getTotalRounds() = turns.size
 
+    /**
+     * @return list of pairs where first is the turn number and second is boolean indicating whether
+     * this death also means end of round
+     */
     fun getDeathMarkers() = turns
         .mapIndexed { index, turn -> index to turn }
         .filter { (_, turn) ->
-            turn.firstOrNull { it is TickEvent }?.let {
-                (it as TickEvent).events.any { e -> e is BotDeathEvent }
-            } ?: false
+            (turn.firstOrNull { it is TickEvent } as TickEvent?)
+                ?.events?.any { it is BotDeathEvent } ?: false
         }
-        .map { it.first }
+        .map { (i, turn) -> i to turn.any { it is RoundEndedEvent } }
 
     override fun getSupportedFeatures(): Set<BattlePlayerFeature> {
         return setOf(BattlePlayerFeature.SEEK)

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/player/ReplayBattlePlayer.kt
@@ -79,6 +79,15 @@ class ReplayBattlePlayer(private val replayFile: File) : BattlePlayer {
 
     fun getTotalRounds() = turns.size
 
+    fun getDeathMarkers() = turns
+        .mapIndexed { index, turn -> index to turn }
+        .filter { (_, turn) ->
+            turn.firstOrNull { it is TickEvent }?.let {
+                (it as TickEvent).events.any { e -> e is BotDeathEvent }
+            } ?: false
+        }
+        .map { it.first }
+
     override fun getSupportedFeatures(): Set<BattlePlayerFeature> {
         return setOf(BattlePlayerFeature.SEEK)
     }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
@@ -61,6 +61,7 @@ object ArenaPanel : JPanel() {
         addComponentListener(object : ComponentAdapter() {
             override fun componentResized(e: ComponentEvent) {
                 recalcScale()
+                repaint()
             }
         })
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SkullComponent.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SkullComponent.kt
@@ -7,8 +7,9 @@ import javax.swing.JComponent
 /**
  * Custom JComponent that renders a skull using Java2D primitives.
  * The component is sized to fit the skull exactly without extra padding.
+ * @param opacity The opacity level for rendering the skull (0.0f - 1.0f), default is 1.0f (100%)
  */
-class SkullComponent : JComponent() {
+class SkullComponent(private val opacity: Float = 1.0f) : JComponent() {
 
     // The actual dimensions of the skull
     private val skullWidth = 14
@@ -30,6 +31,9 @@ class SkullComponent : JComponent() {
         try {
             // Enable anti-aliasing for smoother rendering
             g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            
+            // Apply opacity to all rendering operations
+            g2d.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity)
             
             // Scale to fit the component size
             val scaleX = width.toDouble() / skullWidth

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SkullComponent.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/components/SkullComponent.kt
@@ -1,0 +1,132 @@
+package dev.robocode.tankroyale.gui.ui.components
+
+import java.awt.*
+import java.awt.geom.*
+import javax.swing.JComponent
+
+/**
+ * Custom JComponent that renders a skull using Java2D primitives.
+ * The component is sized to fit the skull exactly without extra padding.
+ */
+class SkullComponent : JComponent() {
+
+    // The actual dimensions of the skull
+    private val skullWidth = 14
+    private val skullHeight = 16
+    
+    init {
+        // Set the preferred size to match the actual skull dimensions
+        preferredSize = Dimension(skullWidth, skullHeight)
+        
+        // Make the component transparent
+        isOpaque = false
+    }
+    
+    override fun paintComponent(g: Graphics) {
+        super.paintComponent(g)
+        
+        val g2d = g.create() as Graphics2D
+        
+        try {
+            // Enable anti-aliasing for smoother rendering
+            g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            
+            // Scale to fit the component size
+            val scaleX = width.toDouble() / skullWidth
+            val scaleY = height.toDouble() / skullHeight
+            g2d.scale(scaleX, scaleY)
+            
+            // Draw the skull shape (translated to start at 0,0 instead of 5,3)
+            drawSkull(g2d)
+            
+            // Draw the eye sockets
+            drawEyeSockets(g2d)
+            
+            // Draw the nose
+            drawNose(g2d)
+            
+            // Draw the teeth
+            drawTeeth(g2d)
+            
+        } finally {
+            g2d.dispose()
+        }
+    }
+    
+    private fun drawSkull(g2d: Graphics2D) {
+        // Create the skull path (adjusted to start at 0,0 instead of 5,3)
+        val skullPath = Path2D.Float()
+        skullPath.moveTo(7.0, 0.0)  // 12,3 -> 7,0 (adjusted)
+        skullPath.curveTo(2.0, 0.0, 0.0, 3.0, 0.0, 7.0)  // 7,3 5,6 5,10 -> 2,0 0,3 0,7
+        skullPath.curveTo(0.0, 9.0, 1.0, 11.0, 3.0, 12.0)  // 5,12 6,14 8,15 -> 0,9 1,11 3,12
+        skullPath.lineTo(3.0, 15.0)  // 8,18 -> 3,15
+        skullPath.lineTo(5.0, 15.0)  // 10,18 -> 5,15
+        skullPath.lineTo(5.0, 16.0)  // 10,19 -> 5,16
+        skullPath.lineTo(9.0, 16.0)  // 14,19 -> 9,16
+        skullPath.lineTo(9.0, 15.0)  // 14,18 -> 9,15
+        skullPath.lineTo(11.0, 15.0)  // 16,18 -> 11,15
+        skullPath.lineTo(11.0, 12.0)  // 16,15 -> 11,12
+        skullPath.curveTo(13.0, 11.0, 14.0, 9.0, 14.0, 7.0)  // 18,14 19,12 19,10 -> 13,11 14,9 14,7
+        skullPath.curveTo(14.0, 3.0, 12.0, 0.0, 7.0, 0.0)  // 19,6 17,3 12,3 -> 14,3 12,0 7,0
+        skullPath.closePath()
+        
+        // Create gradient paint for the skull
+        val skullGradient = GradientPaint(
+            0f, 0f, Color.WHITE,
+            skullWidth.toFloat(), skullHeight.toFloat(), Color(0xDD, 0xDD, 0xDD)
+        )
+        
+        // Fill with gradient
+        g2d.paint = skullGradient
+        g2d.fill(skullPath)
+        
+        // Draw outline
+        g2d.stroke = BasicStroke(0.5f)
+        g2d.color = Color(0x33, 0x33, 0x33)
+        g2d.draw(skullPath)
+    }
+    
+    private fun drawEyeSockets(g2d: Graphics2D) {
+        // Left eye socket (adjusted from cx=9,cy=10 to cx=4,cy=7)
+        g2d.color = Color.BLACK
+        g2d.fill(Ellipse2D.Float(2.0f, 4.5f, 4.0f, 5.0f))
+        
+        // Right eye socket (adjusted from cx=15,cy=10 to cx=10,cy=7)
+        g2d.fill(Ellipse2D.Float(8.0f, 4.5f, 4.0f, 5.0f))
+    }
+    
+    private fun drawNose(g2d: Graphics2D) {
+        // Nose (adjusted from 12,12 11,14 13,14 to 7,9 6,11 8,11)
+        val nosePath = Path2D.Float()
+        nosePath.moveTo(7.0, 9.0)
+        nosePath.lineTo(6.0, 11.0)
+        nosePath.lineTo(8.0, 11.0)
+        nosePath.closePath()
+        
+        g2d.color = Color(0x33, 0x33, 0x33)
+        g2d.fill(nosePath)
+    }
+    
+    private fun drawTeeth(g2d: Graphics2D) {
+        // Draw teeth (adjusted to start at 5,13 instead of 10,16)
+        g2d.color = Color.WHITE
+        
+        for (i in 0..3) {
+            val x = 5.0f + i
+            val y = 13.0f
+            
+            // Fill tooth
+            g2d.fillRect(x.toInt(), y.toInt(), 1, 2)
+            
+            // Draw tooth outline
+            g2d.color = Color(0x33, 0x33, 0x33)
+            g2d.stroke = BasicStroke(0.2f)
+            g2d.drawRect(x.toInt(), y.toInt(), 1, 2)
+            g2d.color = Color.WHITE
+        }
+    }
+    
+    override fun getMinimumSize(): Dimension = preferredSize
+    
+    override fun getMaximumSize(): Dimension = preferredSize
+}

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BaseBotConsolePanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/console/BaseBotConsolePanel.kt
@@ -1,6 +1,7 @@
 package dev.robocode.tankroyale.gui.ui.console
 
 import dev.robocode.tankroyale.client.model.Participant
+import dev.robocode.tankroyale.client.model.TickEvent
 import dev.robocode.tankroyale.gui.client.ClientEvents
 import dev.robocode.tankroyale.gui.ui.Strings
 
@@ -21,7 +22,15 @@ abstract class BaseBotConsolePanel(val bot: Participant) : ConsolePanel() {
             onRoundStarted.subscribe(this@BaseBotConsolePanel) {
                 updateRoundInfo(it.roundNumber)
             }
+            onSeekToTurn.subscribe(this@BaseBotConsolePanel) {
+                informAboutSeek(it)
+            }
         }
+    }
+
+    private fun informAboutSeek(tickEvent: TickEvent) {
+        val text = Strings.get("bot_console.seek_to_turn").format(tickEvent.roundNumber, tickEvent.turnNumber)
+        banner(text)
     }
 
     private fun updateRoundInfo(roundNumber: Int) {
@@ -29,10 +38,14 @@ abstract class BaseBotConsolePanel(val bot: Participant) : ConsolePanel() {
         if (numberOfRounds > 0) {
             roundInfo += "/$numberOfRounds"
         }
+        banner(roundInfo)
+    }
 
-        appendBanner("""
+    private fun banner(text: String) {
+        appendBanner(
+            """
             --------------------
-            $roundInfo
+            $text
             --------------------
         """.trimIndent()
         )

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
@@ -77,11 +77,14 @@ object ControlPanel : JPanel() {
             }
             onGameResumed.subscribe(ControlPanel) {
                 setPausedText()
-
                 nextButton.isEnabled = false
             }
             onGameStarted.subscribe(ControlPanel) {
                 setPausedText()
+            }
+            onGameAborted.subscribe(ControlPanel) {
+                setPausedText()
+                nextButton.isEnabled = false
             }
         }
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ControlPanel.kt
@@ -14,37 +14,51 @@ import dev.robocode.tankroyale.gui.ui.tps.TpsEvents
 import dev.robocode.tankroyale.gui.ui.tps.TpsField
 import dev.robocode.tankroyale.gui.ui.tps.TpsSlider
 import dev.robocode.tankroyale.gui.util.RegisterWsProtocol
+import java.awt.BorderLayout
 import java.awt.EventQueue
+import java.awt.FlowLayout
 import javax.swing.JButton
 import javax.swing.JPanel
 
 object ControlPanel : JPanel() {
 
-    private val pauseResumeButton = addButton("pause", ControlEvents.onPauseResume).apply {
+    private val controlsPanel = JPanel(FlowLayout())
+
+    private val pauseResumeButton = controlsPanel.addButton("pause", ControlEvents.onPauseResume).apply {
         toolTipText = Hints.get("control.pause")
     }
 
-    private val nextButton = addButton("next_turn", ControlEvents.onNextTurn).apply {
+    private val nextButton = controlsPanel.addButton("next_turn", ControlEvents.onNextTurn).apply {
         toolTipText = Hints.get("control.next_turn")
         isEnabled = false
     }
-    private val stopButton = addButton("stop", ControlEvents.onStop).apply {
+    private val stopButton = controlsPanel.addButton("stop", ControlEvents.onStop).apply {
         toolTipText = Hints.get("control.stop")
     }
 
     private val onDefaultTps = Event<JButton>()
 
     init {
-        addButton("restart", ControlEvents.onRestart).apply {
+        // Set BorderLayout for the main panel
+        layout = BorderLayout()
+
+        // Add progress slider at the top (NORTH)
+        add(ProgressSlider, BorderLayout.NORTH)
+
+        // Add controls panel at the bottom (CENTER)
+        add(controlsPanel, BorderLayout.CENTER)
+
+        // Add buttons and controls to the controls panel
+        controlsPanel.addButton("restart", ControlEvents.onRestart).apply {
             toolTipText = Hints.get("control.restart")
         }
 
         RegisterWsProtocol
 
-        add(TpsSlider)
-        val tpsLabel = addLabel("tps_label")
-        add(TpsField)
-        addButton("default_tps", onDefaultTps).apply {
+        controlsPanel.add(TpsSlider)
+        val tpsLabel = controlsPanel.addLabel("tps_label")
+        controlsPanel.add(TpsField)
+        controlsPanel.addButton("default_tps", onDefaultTps).apply {
             toolTipText = Hints.get("control.default_tps").format(DEFAULT_TPS)
         }
 

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -37,7 +37,6 @@ object ProgressSlider : RcSlider() {
         // Initially hide the progress slider until we know the player supports seeking
         isVisible = false
 
-        // Subscribe to player changes to update visibility based on seek capability
         ClientEvents.onPlayerChanged.subscribe(ProgressSlider) { player ->
             EventQueue.invokeLater {
                 isVisible = player.supportsFeature(BattlePlayerFeature.SEEK)
@@ -53,8 +52,8 @@ object ProgressSlider : RcSlider() {
                         updateProgress(eventIndex)
                     }
                     val labelTable = Hashtable<Int, JComponent>()
-                    player.getDeathMarkers().forEach {
-                        labelTable[it] = SkullComponent()
+                    player.getDeathMarkers().forEach { (pos, roundEnd) ->
+                        labelTable[pos] = SkullComponent(if (roundEnd) 1.0f else 0.6f)
                     }
                     this.labelTable = labelTable
                 } else {
@@ -64,6 +63,16 @@ object ProgressSlider : RcSlider() {
                 }
             }
         }
+        ClientEvents.onConnected.subscribe(ProgressSlider) {
+            setEnabled(true)
+        }
+        ClientEvents.onGameAborted.subscribe(ProgressSlider) {
+            setEnabled(false)
+        }
+        ClientEvents.onGameEnded.subscribe(ProgressSlider) {
+            setEnabled(false)
+        }
+
 
         // Add change listener to handle user interaction
         addChangeListener {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -1,8 +1,11 @@
 package dev.robocode.tankroyale.gui.ui.control
 
 import dev.robocode.tankroyale.common.Event
+import dev.robocode.tankroyale.gui.client.ClientEvents
+import dev.robocode.tankroyale.gui.player.BattlePlayerFeature
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.components.RcSlider
+import java.awt.EventQueue
 
 /**
  * Slider component for showing battle progress. This is a dummy component for now,
@@ -22,8 +25,18 @@ object ProgressSlider : RcSlider() {
 
         toolTipText = Hints.get("control.progress")
 
+        // Initially hide the progress slider until we know the player supports seeking
+        isVisible = false
+
+        // Subscribe to player changes to update visibility based on seek capability
+        ClientEvents.onPlayerChanged.subscribe(ProgressSlider) { player ->
+            EventQueue.invokeLater {
+                isVisible = player.supportsFeature(BattlePlayerFeature.SEEK)
+            }
+        }
+
         // Add change listener for future functionality
-        addChangeListener { 
+        addChangeListener {
             if (!valueIsAdjusting) {
                 onProgressChanged.fire(value)
             }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -1,0 +1,39 @@
+package dev.robocode.tankroyale.gui.ui.control
+
+import dev.robocode.tankroyale.common.Event
+import dev.robocode.tankroyale.gui.ui.Hints
+import dev.robocode.tankroyale.gui.ui.components.RcSlider
+
+/**
+ * Slider component for showing battle progress. This is a dummy component for now,
+ * without any control bindings.
+ */
+object ProgressSlider : RcSlider() {
+
+    val onProgressChanged = Event<Int>()
+
+    init {
+        minimum = 0
+        maximum = 100
+        value = 0
+
+        paintTicks = false
+        paintLabels = false
+
+        toolTipText = Hints.get("control.progress")
+
+        // Add change listener for future functionality
+        addChangeListener { 
+            if (!valueIsAdjusting) {
+                onProgressChanged.fire(value)
+            }
+        }
+    }
+
+    /**
+     * Updates the progress value (0-100)
+     */
+    fun setProgress(progress: Int) {
+        value = progress.coerceIn(minimum, maximum)
+    }
+}

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -3,6 +3,7 @@ package dev.robocode.tankroyale.gui.ui.control
 import dev.robocode.tankroyale.common.Event
 import dev.robocode.tankroyale.gui.client.ClientEvents
 import dev.robocode.tankroyale.gui.player.BattlePlayerFeature
+import dev.robocode.tankroyale.gui.player.ReplayBattlePlayer
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.components.RcSlider
 import java.awt.EventQueue
@@ -15,9 +16,12 @@ object ProgressSlider : RcSlider() {
 
     val onProgressChanged = Event<Int>()
 
+    // Default maximum value for the slider
+    private const val DEFAULT_MAX_VALUE = 100
+
     init {
         minimum = 0
-        maximum = 100
+        maximum = DEFAULT_MAX_VALUE
         value = 0
 
         paintTicks = false
@@ -32,7 +36,26 @@ object ProgressSlider : RcSlider() {
         ClientEvents.onPlayerChanged.subscribe(ProgressSlider) { player ->
             EventQueue.invokeLater {
                 isVisible = player.supportsFeature(BattlePlayerFeature.SEEK)
+
+                // Reset to default scale when player changes
+                value = 0
+
+                // If this is a replay player, it will fire the onBattleInfoChanged event
+                // which we'll handle separately
+                if (player is ReplayBattlePlayer) {
+                    maximum = maxOf(player.getEventCount() - 1, 0)
+                    player.onReplayEvent.subscribe(ProgressSlider) { eventIndex ->
+                        updateProgress(eventIndex)
+                    }
+                } else {
+                    maximum = DEFAULT_MAX_VALUE
+                }
             }
+        }
+
+        // Subscribe to tick events to update slider position during playback
+        ClientEvents.onTickEvent.subscribe(ProgressSlider) { tickEvent ->
+
         }
 
         // Add change listener for future functionality
@@ -44,9 +67,21 @@ object ProgressSlider : RcSlider() {
     }
 
     /**
-     * Updates the progress value (0-100)
+     * Updates the progress value within min/max range
      */
     fun setProgress(progress: Int) {
         value = progress.coerceIn(minimum, maximum)
+    }
+
+    /**
+     * Updates the slider position based on the current tick event
+     */
+    private fun updateProgress(eventIndex: Int) {
+        EventQueue.invokeLater {
+            // Only update if we're not currently being adjusted by the user
+            if (!valueIsAdjusting) {
+                setProgress(eventIndex)
+            }
+        }
     }
 }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -1,7 +1,6 @@
 package dev.robocode.tankroyale.gui.ui.control
 
 import dev.robocode.tankroyale.gui.client.ClientEvents
-import dev.robocode.tankroyale.gui.player.BattlePlayerFeature
 import dev.robocode.tankroyale.gui.player.ReplayBattlePlayer
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.components.RcSlider
@@ -39,13 +38,12 @@ object ProgressSlider : RcSlider() {
 
         ClientEvents.onPlayerChanged.subscribe(ProgressSlider) { player ->
             EventQueue.invokeLater {
-                isVisible = player.supportsFeature(BattlePlayerFeature.SEEK)
-
                 // Reset to default scale when player changes
                 value = 0
 
                 // If this is a replay player, subscribe to its events
                 if (player is ReplayBattlePlayer) {
+                    isVisible = true
                     currentReplayPlayer = player
                     maximum = maxOf(player.getTotalRounds() - 1, 0)
                     player.onReplayEvent.subscribe(ProgressSlider) { eventIndex ->
@@ -57,6 +55,7 @@ object ProgressSlider : RcSlider() {
                     }
                     this.labelTable = labelTable
                 } else {
+                    isVisible = false
                     currentReplayPlayer = null
                     maximum = DEFAULT_MAX_VALUE
                     labelTable = null

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -46,7 +46,7 @@ object ProgressSlider : RcSlider() {
                 // If this is a replay player, subscribe to its events
                 if (player is ReplayBattlePlayer) {
                     currentReplayPlayer = player
-                    maximum = maxOf(player.getEventCount() - 1, 0)
+                    maximum = maxOf(player.getTotalRounds() - 1, 0)
                     player.onReplayEvent.subscribe(ProgressSlider) { eventIndex ->
                         updateProgress(eventIndex)
                     }

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -1,6 +1,5 @@
 package dev.robocode.tankroyale.gui.ui.control
 
-import dev.robocode.tankroyale.common.Event
 import dev.robocode.tankroyale.gui.client.ClientEvents
 import dev.robocode.tankroyale.gui.player.BattlePlayerFeature
 import dev.robocode.tankroyale.gui.player.ReplayBattlePlayer
@@ -9,15 +8,19 @@ import dev.robocode.tankroyale.gui.ui.components.RcSlider
 import java.awt.EventQueue
 
 /**
- * Slider component for showing battle progress. This is a dummy component for now,
- * without any control bindings.
+ * Slider component for showing battle progress. This component allows users to
+ * seek to specific positions in a replay by dragging the slider.
  */
 object ProgressSlider : RcSlider() {
 
-    val onProgressChanged = Event<Int>()
-
     // Default maximum value for the slider
     private const val DEFAULT_MAX_VALUE = 100
+
+    // Reference to the current replay player
+    private var currentReplayPlayer: ReplayBattlePlayer? = null
+
+    // Flag to prevent recursive updates when programmatically changing the slider value
+    private var updatingProgrammatically = false
 
     init {
         minimum = 0
@@ -40,28 +43,31 @@ object ProgressSlider : RcSlider() {
                 // Reset to default scale when player changes
                 value = 0
 
-                // If this is a replay player, it will fire the onBattleInfoChanged event
-                // which we'll handle separately
+                // If this is a replay player, subscribe to its events
                 if (player is ReplayBattlePlayer) {
+                    currentReplayPlayer = player
                     maximum = maxOf(player.getEventCount() - 1, 0)
                     player.onReplayEvent.subscribe(ProgressSlider) { eventIndex ->
                         updateProgress(eventIndex)
                     }
                 } else {
+                    currentReplayPlayer = null
                     maximum = DEFAULT_MAX_VALUE
                 }
             }
         }
 
-        // Subscribe to tick events to update slider position during playback
-        ClientEvents.onTickEvent.subscribe(ProgressSlider) { tickEvent ->
-
-        }
-
-        // Add change listener for future functionality
+        // Add change listener to handle user interaction
         addChangeListener {
-            if (!valueIsAdjusting) {
-                onProgressChanged.fire(value)
+            // Only handle user-initiated changes, not programmatic ones
+            if (!updatingProgrammatically) {
+                if (valueIsAdjusting) {
+                    // When the user starts dragging, pause the replay
+                    currentReplayPlayer?.pause()
+                } else {
+                    // When the user finishes dragging, seek to the selected position
+                    currentReplayPlayer?.seekToTurn(value)
+                }
             }
         }
     }
@@ -70,11 +76,17 @@ object ProgressSlider : RcSlider() {
      * Updates the progress value within min/max range
      */
     fun setProgress(progress: Int) {
-        value = progress.coerceIn(minimum, maximum)
+        // Set flag to prevent recursive updates
+        updatingProgrammatically = true
+        try {
+            value = progress.coerceIn(minimum, maximum)
+        } finally {
+            updatingProgrammatically = false
+        }
     }
 
     /**
-     * Updates the slider position based on the current tick event
+     * Updates the slider position based on the current event index
      */
     private fun updateProgress(eventIndex: Int) {
         EventQueue.invokeLater {

--- a/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
+++ b/gui-app/src/main/kotlin/dev/robocode/tankroyale/gui/ui/control/ProgressSlider.kt
@@ -5,7 +5,10 @@ import dev.robocode.tankroyale.gui.player.BattlePlayerFeature
 import dev.robocode.tankroyale.gui.player.ReplayBattlePlayer
 import dev.robocode.tankroyale.gui.ui.Hints
 import dev.robocode.tankroyale.gui.ui.components.RcSlider
+import dev.robocode.tankroyale.gui.ui.components.SkullComponent
 import java.awt.EventQueue
+import java.util.*
+import javax.swing.JComponent
 
 /**
  * Slider component for showing battle progress. This component allows users to
@@ -27,9 +30,8 @@ object ProgressSlider : RcSlider() {
         maximum = DEFAULT_MAX_VALUE
         value = 0
 
-        paintTicks = false
-        paintLabels = false
-
+        paintTicks = true
+        paintLabels = true
         toolTipText = Hints.get("control.progress")
 
         // Initially hide the progress slider until we know the player supports seeking
@@ -50,9 +52,15 @@ object ProgressSlider : RcSlider() {
                     player.onReplayEvent.subscribe(ProgressSlider) { eventIndex ->
                         updateProgress(eventIndex)
                     }
+                    val labelTable = Hashtable<Int, JComponent>()
+                    player.getDeathMarkers().forEach {
+                        labelTable[it] = SkullComponent()
+                    }
+                    this.labelTable = labelTable
                 } else {
                     currentReplayPlayer = null
                     maximum = DEFAULT_MAX_VALUE
+                    labelTable = null
                 }
             }
         }

--- a/gui-app/src/main/resources/Hints.properties
+++ b/gui-app/src/main/resources/Hints.properties
@@ -50,6 +50,9 @@ control.tps=\
 control.default_tps=\
   Resets the Turns Per Second (TPS) to the default: %d
 
+control.progress=\
+  Shows the current progress of the battle.
+
 # Debug Options
 option.enable_initial_position=\
   Server-option for allowing your bot(s) to start with an initial starting position.<br>\

--- a/gui-app/src/main/resources/Strings.properties
+++ b/gui-app/src/main/resources/Strings.properties
@@ -85,6 +85,7 @@ bot_console.properties.value=Value
 bot_console.bot_died=Bot died
 bot_console.game_has_ended=The game has ended
 bot_console.game_was_aborted=The game was aborted!
+bot_console.seek_to_turn=Seek to round %d turn %d
 # Bot Properties
 toggle_graphical_debugging=Toggle Graphical Debugging
 # TPS


### PR DESCRIPTION
This PR adds a timeline progress slider to the battle replay functionality, allowing users to visually track battle progress and navigate through replays. The implementation includes visual indicators for bot deaths and improved user experience when seeking through replay battles.

#### Key Features
* Progress Slider: Added a timeline slider at the top of the control panel that tracks replay battle progress
* Death Indicators: Visual skull icons on the progress slider marking when bots die during battle
* Seeking Functionality: Users can click or drag the slider to navigate to specific points in the replay
* Pause on Seek: Battle automatically pauses when user drags the progress bar for better control
* Visual Distinction: Different visual indicators for deaths during rounds vs. at round end
* Improved Bot Console: Added informational messages when seeking through replays

Closes #55 