### PR TITLE
Update rec indicator visuals

### DIFF
--- a/gui/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
+++ b/gui/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
@@ -32,7 +32,7 @@ object ArenaPanel : JPanel() {
     // Game status indicator constants
     private const val INDICATOR_BACKGROUND_OPACITY = 0.8f
     private const val INDICATOR_SHADOW_OPACITY = 0.3f
-    private val INDICATOR_LIVE_BG_COLOR = Color(27,79,114) // Crimson blue (solid)
+    private val INDICATOR_LIVE_BG_COLOR = Color(0, 120, 215) // "MS Edge Blue" to match sliders on Windows (solid)
     private val INDICATOR_LIVE_REC_BG_COLOR = Color(220, 20, 60) // Crimson red (solid)
     private val INDICATOR_REPLAY_BG_COLOR = Color(40, 40, 40) // Dark gray (solid)
     private val INDICATOR_ROUND_BG_COLOR = Color(60, 60, 60, (255 * INDICATOR_BACKGROUND_OPACITY).toInt()) // Medium dark gray

--- a/gui/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
+++ b/gui/src/main/kotlin/dev/robocode/tankroyale/gui/ui/arena/ArenaPanel.kt
@@ -386,7 +386,9 @@ object ArenaPanel : JPanel() {
         // Draw drop shadow
         g.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, INDICATOR_SHADOW_OPACITY)
         g.color = INDICATOR_SHADOW_COLOR
-        g.fillRoundRect((x + 2).toInt(), (y + 2).toInt(), totalWidth, INDICATOR_HEIGHT.toInt(), INDICATOR_CORNER_RADIUS, INDICATOR_CORNER_RADIUS)
+        val shadow = Area(RoundRectangle2D.Double((x + 2), (y + 2), totalWidth.toDouble(), INDICATOR_HEIGHT, INDICATOR_CORNER_RADIUS.toDouble(), INDICATOR_CORNER_RADIUS.toDouble()))
+        shadow.subtract(Area(RoundRectangle2D.Double(x, y, totalWidth.toDouble(), INDICATOR_HEIGHT, INDICATOR_CORNER_RADIUS.toDouble(), INDICATOR_CORNER_RADIUS.toDouble())))
+        g.fill(shadow)
         g.composite = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1.0f)
 
         // Draw all sections pixel-perfect without overlaps


### PR DESCRIPTION
- Change REC indicator visuals to display a REC text with pulsating red dot on the left side of the status (LIVE) indicator, instead of plain "LIVE REC" text
- Modify indicator shadow rendering (technically, the status parts are semi transparent, but the shadow does not look very good under them
- Update the shade of blue used for (non-rec) LIVE indicator to match the Windows palette (i.e. to match the sliders)