### PR TITLE
Prevent overwriting UI scale property for high DPI displays if alread…

### DIFF
--- a/gui/src/main/kotlin/dev/robocode/tankroyale/gui/GuiApp.kt
+++ b/gui/src/main/kotlin/dev/robocode/tankroyale/gui/GuiApp.kt
@@ -11,10 +11,10 @@ import java.util.Locale
 fun main() {
     val scale = try { ConfigSettings.uiScale } catch (_: Exception) { 100 }
 
-    //set ui scale factor for high dpi displays
-
-    System.setProperty("sun.java2d.uiScale", (scale/100).toString()) // default
-
+    //set ui scale factor for high dpi displays, but only if not already set (via command line)
+    if (System.getProperty("sun.java2d.uiScale") == null) {
+        System.setProperty("sun.java2d.uiScale", (scale/100).toString()) // default
+    }
     try {
         Taskbar.getTaskbar().iconImage = RcImages.tankImage // for macOS
     } catch (_: UnsupportedOperationException) {


### PR DESCRIPTION
…y set (via command line)

It's a suggestion, I think this don't interfere with your desired way of doing things.
So, I can continue calling my script to launch the robocode jar in my laptop or my desktop:

```bash
# Script para lanzar Robocode con diferente escala según el dispositivo

echo "¿Dónde estás ejecutando el programa?"
echo "1) Portátil"
echo "2) Fijo"
echo -n "Selecciona una opción (1 o 2): "

read opcion

case $opcion in
    1)
        echo "Configurando para portátil (uiScale=2)..."
        java -Dsun.java2d.uiScale=2 -jar robocode-tankroyale-gui-0.34.0.jar
        ;;
    2)
        echo "Configurando para equipo fijo (uiScale=1)..."
        java -Dsun.java2d.uiScale=1 -jar robocode-tankroyale-gui-0.34.0.jar
        ;;
    *)
        echo "Opción no válida. Saliendo."
        exit 1
        ;;
esac
``