### PR TITLE
Add foojay-resolver plugin for automatic JDK downloads

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+  // Apply the foojay-resolver plugin to allow automatic download of JDKs
+  id("org.gradle.toolchains.foojay-resolver-convention")
+}
+
 rootProject.name = "buildSrc"
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+  // Apply the foojay-resolver plugin to allow automatic download of JDKs
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "Robocode Tank Royale"
 
 val version: String = providers.gradleProperty("version").get()


### PR DESCRIPTION
Problem
--------

The project requires Java 11 for compilation (configured via toolchains in `build.gradle.kts`), but Gradle 9 itself requires Java 17+ to run and does not support running with Java 11. This creates a situation where I was unable the build the project:
````
Cannot find a Java installation on your machine matching: {languageVersion=11, ...}.
Toolchain download repositories have not been configured.
````

Solution
--------

Let Gradle automatically download the required Java 11 JDK when building with a different Java version. I've added the foojay-resolver-convention plugin which configures toolchain download repositories, allowing Gradle to automatically download and use Java 11 for compilation.
