### PR TITLE
Fix devcontainer JAVA_HOME to support both amd64 and ARM64 architectures

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # Set environment variables
 # Use Java 17 as default (for Gradle 9.x), but Java 11 is available as toolchain
-ENV JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-amd64
+# Create architecture-independent symlink for JAVA_HOME
+RUN ln -s /usr/lib/jvm/temurin-17-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-17-jdk
+ENV JAVA_HOME=/usr/lib/jvm/temurin-17-jdk
 ENV DOTNET_ROOT=/usr/share/dotnet
 
 # Install DocFX 2.78.4 as a .NET tool


### PR DESCRIPTION
The devcontainer Dockerfile had JAVA_HOME hardcoded to `/usr/lib/jvm/temurin-17-jdk-amd64`, which broke the development environment on ARM64 systems (e.g., Apple Silicon Macs).

Instead of hardcoding the architecture, the Dockerfile now:
  1. Uses `dpkg --print-architecture` at build time to detect the system architecture
  2. Creates a symlink from `/usr/lib/jvm/temurin-17-jdk` to the architecture-specific JDK path
  3. Sets JAVA_HOME to the generic symlink path