### PR TITLE
docs(CH-003): verify provenance of TypeScript npm-publishing artifacts

### DIFF
--- a/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/README.md
+++ b/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/README.md
@@ -4,7 +4,7 @@ type: capability
 status: draft
 links: [G-001]
 title: TypeScript Bot API npm publishing
-provenance: inferred
+provenance: verified
 ---
 
 # CAP-013 — TypeScript Bot API npm publishing

--- a/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/criteria.md
+++ b/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/criteria.md
@@ -5,7 +5,7 @@ status: draft
 links: [CAP-013]
 title: Acceptance criteria for CAP-013 (typescript-bot-api-npm-publish)
 ac-prefix: TNP
-provenance: inferred
+provenance: verified
 ---
 
 ```gherkin

--- a/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/design.md
+++ b/docs/capabilities/CAP-013-typescript-bot-api-npm-publish/design.md
@@ -4,7 +4,7 @@ type: design
 status: draft
 links: [CAP-013, P-002]
 title: Design notes for CAP-013 (typescript-bot-api-npm-publish)
-provenance: inferred
+provenance: verified
 ---
 
 # CAP-013 design

--- a/docs/plans/P-002-typescript-bot-api-npm.md
+++ b/docs/plans/P-002-typescript-bot-api-npm.md
@@ -4,7 +4,7 @@ type: plan
 status: completed
 links: [G-001]
 title: TypeScript Bot API reaches npm
-provenance: inferred
+provenance: verified
 ---
 
 # P-002 — TypeScript Bot API reaches npm


### PR DESCRIPTION
## CH-003 — Verify provenance of the TypeScript npm-publishing artifacts

Light-tier follow-up to CH-002 (#219). Promotes `provenance: inferred` → `verified` on the four artifacts that CH-002 reconciled and you reviewed on merge:

- `docs/plans/P-002-typescript-bot-api-npm.md`
- `docs/capabilities/CAP-013-typescript-bot-api-npm-publish/README.md`
- `.../criteria.md`
- `.../design.md`

These were born `inferred` at the CH-001 extraction. They now match the shipped implementation and your real credential setup (`npmjs-api-key` in `~/.gradle/gradle.properties`), verified by human review — so `verified` is the honest flag. This drops the corpus "awaiting verification" count from 71 → 67.

**Note:** CAP-013 criteria stay `status: draft` — provenance (human-checked-against-reality) and status (test-wired, the M-002 door) are independent axes.

### Why light tier
No acceptance-criterion meaning, decision, or plan-semantic change — pure verification-flag bookkeeping. PR description is the proposal.

### Verification
`clue validate` → OK (115 artifacts, 67 born inferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
