### PR TITLE
fix(ci): pin Cliewen workflow to release commit

### DIFF
--- a/.github/workflows/clue.yml
+++ b/.github/workflows/clue.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   validate:
     name: validate
-    uses: cliewen/cliewen/.github/workflows/clue-validation.yml@bf7cfa6d91828791e8af0080bcd8765ec7e592eb
+    uses: cliewen/cliewen/.github/workflows/clue-validation.yml@eace76def495123c4af8dc4c9e29f278c30d952b
     with:
       runner: '["ubuntu-latest"]'
       clue-version: 0.16.0


### PR DESCRIPTION
## Summary

Correct the Cliewen reusable-workflow pin to the commit named by the annotated `v0.16.0` tag.

## Root cause

The previous pin used the annotated tag object's SHA (`bf7cfa6d…`) rather than its peeled commit SHA. GitHub Actions cannot resolve the tag object as a reusable-workflow revision, so the workflow failed before creating a job.

## Impact

The `validate` job can start again on pull requests and pushes to `main`. This restores the already-intended CI behavior and does not change product or corpus meaning.

## Verification

- Confirmed `eace76def495123c4af8dc4c9e29f278c30d952b` is a commit in `cliewen/cliewen`.
- Confirmed that commit contains `.github/workflows/clue-validation.yml`.
- `clue validate --forbid-changes` passes.
- `git diff --check origin/main...HEAD` passes.

## Cliewen routing

Recommended and implemented route: simple. This is a defect correction to an invalid CI reference; no CH workspace or corpus bookkeeping is required.