### PR TITLE
fix(dotnet): wire .NET tests into Gradle check, fix process crash and stale test failures

### DIFF
--- a/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
+++ b/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
@@ -332,7 +332,13 @@ sealed class BaseBotInternals
     internal void Start()
     {
         Connect();
-        _closedEvent.WaitOne();
+        try
+        {
+            _closedEvent.WaitOne();
+        }
+        catch (ThreadInterruptedException)
+        {
+        }
     }
 
     private void Connect()

--- a/bot-api/dotnet/build.gradle.kts
+++ b/bot-api/dotnet/build.gradle.kts
@@ -69,12 +69,16 @@ tasks {
         isIgnoreExitValue = true
     }
 
-    register<Exec>("test") {
+    val test by registering(Exec::class) {
         dependsOn(":bot-api:dotnet:schema:build")
         dependsOn("restoreTestBeforeBuild")
 
         workingDir = File(projectDir, "test")
         commandLine("dotnet", "test")
+    }
+
+    named("check") {
+        dependsOn(test)
     }
 
     named("build") {

--- a/bot-api/dotnet/test/src/WonRoundEventTest.cs
+++ b/bot-api/dotnet/test/src/WonRoundEventTest.cs
@@ -10,30 +10,38 @@ namespace Robocode.TankRoyale.BotApi.Tests;
 [Property("ID", "TR-API-TCK-005")]
 public class WonRoundEventTest : AbstractBotTest
 {
+    /// <summary>
+    /// BaseBot has no internal thread and no Go() loop of its own in this scenario, so the only
+    /// path that can deliver a WonRoundEvent carried by the round's final tick is the
+    /// RoundEnded-triggered dispatch in BaseBotInternals.HandleRoundEnded (regression coverage
+    /// for the "final-tick events dropped" bug fix). Mirrors the Java counterpart
+    /// (WonRoundEventTest.baseBot_whenTickContainsWonRoundEvent_thenOnWonRoundIsCalled), which
+    /// likewise never calls go() and relies solely on the server sending RoundEndedEventForBot
+    /// after the winning tick.
+    /// </summary>
     [Test]
-    [Ignore("Temporarily skip to establish baseline for Phase 5 cleanup")]
     public void BaseBot_WhenTickContainsWonRoundEvent_ThenOnWonRoundIsCalled()
     {
         var wonRoundLatch = new CountdownEvent(1);
         var bot = new TestWonRoundBot(Server.ServerUrl, wonRoundLatch);
-        
+
         StartAsync(bot);
-        
+
         AwaitBotHandshake();
-        // MockedServer automatically sends GameStarted and RoundStarted
-        
-        // Add WonRoundEvent to the next tick
+        // MockedServer automatically sends GameStarted, RoundStarted, and the first tick
+        // once the bot replies with BotReady.
+        Assert.That(Server.AwaitTick(2000), Is.True);
+
+        // Add WonRoundEvent to the next ("winning") tick.
         Server.AddEvent(new Robocode.TankRoyale.Schema.WonRoundEvent {
             Type = "WonRoundEvent",
-            TurnNumber = 1
+            TurnNumber = 2
         });
-        
-        Server.SetBotStateAndAwaitTick();
-        
-        // BaseBot needs to call Go() to dispatch events from the queue
-        bot.Go();
-        
-        // BaseBot should receive the event
+        Assert.That(Server.SetBotStateAndAwaitTick(), Is.True);
+
+        // No bot.Go() here — deliberately. Delivery must come from RoundEnded dispatch.
+        Server.SendRoundEndedForBot(1, 2);
+
         bool received = wonRoundLatch.Wait(TimeSpan.FromSeconds(5));
         Assert.That(received, Is.True, "onWonRound() should be called within 5 seconds");
     }

--- a/bot-api/dotnet/test/src/internal/SharedTestRunner.cs
+++ b/bot-api/dotnet/test/src/internal/SharedTestRunner.cs
@@ -133,7 +133,11 @@ public class SharedTestRunner
                 case "fromRgba": lastActionValue = Color.FromRgba(Convert.ToUInt32(args[0]), Convert.ToUInt32(args[1]), Convert.ToUInt32(args[2]), Convert.ToUInt32(args[3])); break;
                 case "colorToHex": lastActionValue = IntentValidator.ColorToHex((Color)args[0]); break;
                 case "getColorConstant": lastActionValue = GetStaticField(typeof(Color), (string)args[0]); break;
-                case "getConstant": lastActionValue = GetStaticField(typeof(Constants), (string)args[0]); break;
+                case "getConstant":
+                    lastActionValue = GetStaticField(typeof(Constants), (string)args[0])
+                        ?? GetStaticField(typeof(GameType), (string)args[0])
+                        ?? GetStaticField(typeof(DefaultEventPriority), (string)args[0]);
+                    break;
                 case "isCritical": lastActionValue = CreateEvent((string)args[0]).IsCritical; break;
                 case "getDefaultPriority": lastActionValue = GetStaticField(typeof(DefaultEventPriority), (string)args[0]); break;
                 case "calcBulletSpeed": lastActionValue = mockBot.CalcBulletSpeed(Convert.ToDouble(args[0])); break;
@@ -233,9 +237,15 @@ public class SharedTestRunner
 
     private object GetStaticField(Type type, string fieldName)
     {
-        var normalized = fieldName.Replace("_", "");
+        // Shared test JSON uses names like "WonRoundEvent" / "MAX_SPEED"; API constants are
+        // PascalCase without the "Event" suffix (e.g. WonRound, MaxSpeed). Mirrors the Java
+        // SharedTestRunner's normalization, with a fallback to the raw name.
+        var normalized = fieldName.Replace("Event", "").Replace("_", "");
         var flags = BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase;
-        return type.GetField(normalized, flags)?.GetValue(null) ?? type.GetProperty(normalized, flags)?.GetValue(null);
+        return type.GetField(normalized, flags)?.GetValue(null)
+            ?? type.GetProperty(normalized, flags)?.GetValue(null)
+            ?? type.GetField(fieldName, flags)?.GetValue(null)
+            ?? type.GetProperty(fieldName, flags)?.GetValue(null);
     }
 
     private BotEvent CreateEvent(string eventName)

--- a/bot-api/dotnet/test/src/test_utils/MockedServer.cs
+++ b/bot-api/dotnet/test/src/test_utils/MockedServer.cs
@@ -503,7 +503,10 @@ public class MockedServer
 
     private static void OnError(Exception ex)
     {
-        throw new InvalidOperationException("MockedServer error", ex);
+        // Fleck invokes this on its own I/O thread. Rethrowing here would surface as an
+        // unhandled exception on a background thread, which crashes the whole test host
+        // process instead of failing the individual test.
+        Console.Error.WriteLine("[Error] MockedServer connection error: " + ex);
     }
 
     private static int FindAvailablePort()
@@ -541,6 +544,37 @@ public class MockedServer
     {
         if (_conn == null) throw new InvalidOperationException("No connection");
         SendRoundStarted(_conn);
+    }
+
+    /// <summary>
+    /// Sends a RoundEndedEventForBot message, e.g. to trigger BaseBot's RoundEnded-triggered
+    /// dispatch of any events (such as WonRoundEvent) carried by the final tick of the round.
+    /// </summary>
+    public void SendRoundEndedForBot(int roundNumber, int turnNumber)
+    {
+        if (_conn == null) throw new InvalidOperationException("No connection");
+
+        var roundEnded = new RoundEndedEventForBot
+        {
+            Type = EnumUtil.GetEnumMemberAttrValue(MessageType.RoundEndedEventForBot),
+            RoundNumber = roundNumber,
+            TurnNumber = turnNumber,
+            Results = new Schema.ResultsForBot
+            {
+                Rank = 1,
+                Survival = 0,
+                LastSurvivorBonus = 0,
+                BulletDamage = 0,
+                BulletKillBonus = 0,
+                RamDamage = 0,
+                RamKillBonus = 0,
+                TotalScore = 0,
+                FirstPlaces = 0,
+                SecondPlaces = 0,
+                ThirdPlaces = 0
+            }
+        };
+        Send(_conn, roundEnded);
     }
 
     private static void SendGameStartedForBot(IWebSocketConnection conn)


### PR DESCRIPTION
## Summary

- `bot-api/dotnet/build.gradle.kts`: attach the existing `test` Exec task to `check` so `./gradlew build`/`clean build` actually runs `dotnet test` instead of silently skipping it. Python already had this wiring; .NET never did.
- `BaseBotInternals.Start()`: wrap `_closedEvent.WaitOne()` in `catch (ThreadInterruptedException)`. Interrupting the thread that's running `Start()` (as several tests do for cleanup) previously threw an unhandled exception on a foreground thread, which crashes the entire .NET test host process — this is why the .NET test task had never been wired into `check` in the first place.
- `MockedServer.OnError`: log connection errors instead of rethrowing them on Fleck's own I/O thread (secondary hardening, same crash class).
- `SharedTestRunner.GetStaticField` / `getConstant`: port the Java counterpart's field-name normalization (strip the `Event` suffix, fall back across `Constants` → `GameType` → `DefaultEventPriority`). Without it, the shared cross-platform constant and event-priority tests were silently comparing against `null` and failing.
- `WonRoundEventTest`: fixed to match the Java counterpart's approach. `BaseBot` has no `Go()` loop in this scenario, so `OnWonRound` can only fire via the `RoundEnded`-triggered dispatch path (`BaseBotInternals.HandleRoundEnded`) — the fix for the historical "final-tick events dropped" bug. Added `MockedServer.SendRoundEndedForBot` and removed the `bot.Go()` call that never actually exercised that path, which is why this test had been left `[Ignore(...)]` since the Phase 5 test-infrastructure unification.

## Test plan

- [x] `dotnet test` in `bot-api/dotnet/test`: 269 passed, 0 failed, 0 skipped (was: process crash after ~250 tests, then 18 failures once the crash was fixed, then 1 skipped once those were fixed)
- [x] `./gradlew clean build` from repo root: `BUILD SUCCESSFUL`, `:bot-api:dotnet:test` → `:bot-api:dotnet:check` → `:bot-api:dotnet:build` all run and pass as part of the normal build graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
