### PR TITLE
fix(typescript): wire tests into Gradle check

### DIFF
--- a/bot-api/typescript/build.gradle.kts
+++ b/bot-api/typescript/build.gradle.kts
@@ -154,8 +154,12 @@ tasks {
         dependsOn(npmBuild)
     }
 
-    register("test") {
+    val test by registering {
         dependsOn(npmTest)
+    }
+
+    named("check") {
+        dependsOn(test)
     }
 
     // Make sure documentation tasks are not part of the build task


### PR DESCRIPTION
## Summary

- `bot-api/typescript/build.gradle.kts`: attach the existing `test` task (which runs `npm run test` via `npmTest`) to `check`, so `./gradlew build`/`clean build` actually runs the TypeScript test suite instead of silently skipping it.

Same class of gap fixed for .NET in #240 — Python already had `check.dependsOn(test)`. Unlike the .NET case, the TypeScript tests already pass cleanly standalone, so this is a pure wiring fix with no test-code changes.

## Test plan

- [x] `./gradlew :bot-api:typescript:build`: `test` → `check` → `build` all run in order, `BUILD SUCCESSFUL`, 15 test files / 280 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
