### PR TITLE
Switch to using maintained nv-i18n fork

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ flatlaf = "3.5.4"
 miglayout-swing = "11.4.2"
 nexus-publish = "2.0.0"
 node-gradle = "7.1.0"
-nv-i18n = "1.29"
+nv-i18n = "1.33"
 shadow = "9.6.1"
 slf4j-api = "2.0.12"
 
@@ -33,7 +33,7 @@ clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 flatlaf = { module = "com.formdev:flatlaf", version.ref = "flatlaf" }
 miglayout-swing = { module = "com.miglayout:miglayout-swing", version.ref = "miglayout-swing" }
-nv-i18n = { module = "com.neovisionaries:nv-i18n", version.ref = "nv-i18n" }
+nv-i18n = { module = "uk.co.foundationsedge:nv-i18n", version.ref = "nv-i18n" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }
 
 [bundles]


### PR DESCRIPTION

## Acceptance brief

Raised as ticket https://github.com/robocode-dev/tank-royale/issues/238 and approved for a PR to be raised.

## Summary

Switching to maintained fork at `uk.co.foundationsedge:nv-i18n`

`com.neovisionaries:nv-i18n:1.29` ->`uk.co.foundationsedge:nv-i18n:1.33`

`com.neovisionaries:nv-i18n` is no longer maintained.

## Verification

Ran the `bot-api` tests and had all passing. @flemming-n-larsen confirmed they had likewise from my branch.
