### PR TITLE
test: stabilize mocked bot readiness in CI

### DIFF
--- a/bot-api/dotnet/test/src/MockedServerTest.cs
+++ b/bot-api/dotnet/test/src/MockedServerTest.cs
@@ -8,11 +8,13 @@ namespace Robocode.TankRoyale.BotApi.Tests;
 [Property("ID", "TR-API-UTL-003")]
 public class MockedServerTest : AbstractBotTest
 {
+    private const int BotReadyTimeoutMs = 10_000;
+
     [Test]
     public void TestAwaitBotReady()
     {
         var bot = Start();
-        Assert.That(Server.AwaitBotReady(1000), Is.True);
+        Assert.That(Server.AwaitBotReady(BotReadyTimeoutMs), Is.True);
     }
 
     [Test]

--- a/bot-api/dotnet/test/src/MockedServerThreadSafetyTest.cs
+++ b/bot-api/dotnet/test/src/MockedServerThreadSafetyTest.cs
@@ -15,6 +15,8 @@ namespace Robocode.TankRoyale.BotApi.Tests;
 [Property("ID", "TR-API-UTL-004")]
 public class MockedServerThreadSafetyTest : AbstractBotTest
 {
+    private const int BotReadyTimeoutMs = 10_000;
+
     [Test]
     [Category("Reliability")]
     [Description("Verify SetInitialBotState is thread-safe")]
@@ -22,7 +24,7 @@ public class MockedServerThreadSafetyTest : AbstractBotTest
     {
         // Arrange: Start bot and ensure it's ready
         var bot = Start();
-        Assert.That(Server.AwaitBotReady(2000), Is.True, "Bot failed to become ready");
+        Assert.That(Server.AwaitBotReady(BotReadyTimeoutMs), Is.True, "Bot failed to become ready");
 
         // Act: Update state from multiple threads concurrently (simulating what test setup might do)
         var tasks = new Task[10];
@@ -43,7 +45,7 @@ public class MockedServerThreadSafetyTest : AbstractBotTest
     {
         // Arrange: Start bot and ensure it's ready with proper connection
         var bot = Start();
-        Assert.That(Server.AwaitBotReady(2000), Is.True, "Bot failed to become ready");
+        Assert.That(Server.AwaitBotReady(BotReadyTimeoutMs), Is.True, "Bot failed to become ready");
 
         // Act & Assert: Sequential state updates should work reliably
         Assert.That(Server.SetBotStateAndAwaitTick(energy: 75.0), Is.True, "First state update failed");
@@ -58,7 +60,7 @@ public class MockedServerThreadSafetyTest : AbstractBotTest
     {
         // Arrange & Act: Start bot and verify ready state
         var bot = Start();
-        var success = Server.AwaitBotReady(2000);
+        var success = Server.AwaitBotReady(BotReadyTimeoutMs);
 
         // Assert: Bot should reach ready state without race conditions
         Assert.That(success, Is.True, "Bot failed to reach ready state");
@@ -84,7 +86,7 @@ public class MockedServerThreadSafetyTest : AbstractBotTest
     {
         // Arrange: Start bot and ensure it's ready
         var bot = Start();
-        Assert.That(Server.AwaitBotReady(2000), Is.True, "Bot failed to become ready");
+        Assert.That(Server.AwaitBotReady(BotReadyTimeoutMs), Is.True, "Bot failed to become ready");
 
         // Act: Set up concurrent operations
         var stateUpdateTask = Task.Run(() =>


### PR DESCRIPTION
## Summary
- Allow the mocked bot handshake-to-ready sequence up to 10 seconds in CI.
- Apply the same timeout to the MockedServer utility and thread-safety tests.

## Verification
- Focused MockedServer tests: passed (6/6).
- Full .NET test suite: passed (269/269).