### PR TITLE
Restore real NuGet push after OIDC handshake test

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           user: ${{ vars.NUGET_USERNAME }}
 
-      - name: TEMP - verify key received, no push (OIDC handshake test)
+      - name: NuGet push
         run: |
-          KEY="${{ steps.login.outputs.NUGET_API_KEY }}"
-          echo "Got NuGet API key: ${#KEY} chars"
+          dotnet nuget push \
+            "bot-api/dotnet/api/bin/Release/robocode.tankroyale.botapi.${{ inputs.version }}.nupkg" \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary

Follow-up to #255. Confirmed the OIDC → NuGet Trusted Publishing handshake works end-to-end (workflow run [34018830847](https://github.com/robocode-dev/tank-royale/actions/runs/34018830847) returned a real 84-char temporary API key, no publish attempted). This restores the actual `dotnet nuget push` step, replacing the temporary echo placeholder.

`publish-nuget.yml` is now release-ready. The next real release exercises the full path (build → push → visible on nuget.org) for the first time, which will also move the nuget.org Trusted Publishing policy out of its 7-day pending-activation state.

## Test plan

- [x] OIDC handshake verified with no-op push (run 34018830847)
- [ ] First real release publishes successfully via `publish-nuget.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132M9BMK7BuCAeCN31xBUNv
