### PR TITLE
fix: isolate bot lifecycle across rounds and align the four Bot APIs

### DIFF
--- a/.clue/id-ledger.yaml
+++ b/.clue/id-ledger.yaml
@@ -9,8 +9,8 @@ counters:
     GTD: "1"
     IDR: "4"
     LOG: "1"
-    P: "3"
-    PDR: "12"
+    P: "5"
+    PDR: "13"
     RBC: "4"
     RCL: "11"
     TNP: "3"
@@ -729,6 +729,11 @@ entries:
       state: live
       prefix: P
       component: "3"
+    - id: P-005
+      kind: numeric
+      state: live
+      prefix: P
+      component: "5"
     - id: PDR-001
       kind: numeric
       state: live
@@ -789,6 +794,11 @@ entries:
       state: live
       prefix: PDR
       component: "12"
+    - id: PDR-013
+      kind: numeric
+      state: live
+      prefix: PDR
+      component: "13"
     - id: RBC-001
       kind: numeric
       state: live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [Unreleased] - Round lifecycle isolation
+
+### 🐞 Bug Fixes
+
+- Bot API (Java, .NET, Python, TypeScript):
+    - Fixed events from the last turn of a round, such as `onWonRound` and `onDeath`, being lost when the game ended, when it was aborted, or when the connection to the server dropped.
+    - Fixed a bot's `run()` method from a finished round being able to send commands into the round that follows it.
+    - Fixed an unexpected exception thrown from `run()` discarding the bot's remaining events for that turn.
+- Bot API (TypeScript):
+    - Fixed `onWonRound` being called twice when a bot won a round.
+    - An unexpected exception thrown from `run()` is now reported instead of being silently ignored.
+
+### 🔧 Changes
+
+- Bot API (.NET, TypeScript):
+    - `X`, `Y`, `Direction`, `GunDirection`, and `RadarDirection` now fall back to the bot's initial position when read before the first turn of a game, which is what the Java and Python Bot APIs already did. They still throw a `BotException` when no initial position is available.
+- Bot API (Python):
+    - Calling `go()` on a `BaseBot` that has no `run()` method now stops the rest of the calling event handler after the intent has been sent, matching the Java and .NET Bot APIs.
+
 ## [1.2.0] - 2026-09-05 - Runner compatibility precondition
 
 ### 🐞 Bug Fixes

--- a/bot-api/dotnet/api/src/BaseBot.cs
+++ b/bot-api/dotnet/api/src/BaseBot.cs
@@ -180,19 +180,69 @@ public abstract class BaseBot : IBaseBot
     public bool IsDisabled => Energy == 0;
 
     /// <inheritdoc/>
-    public double X => BaseBotInternals.CurrentTickOrThrow.BotState.X;
+    public double X
+    {
+        get
+        {
+            var tick = BaseBotInternals.CurrentTickOrNull;
+            if (tick != null) return tick.BotState.X;
+            var initialPosition = BaseBotInternals.InitialPosition;
+            if (initialPosition?.X != null) return initialPosition.X.Value;
+            throw new BotException(BaseBotInternals.TickNotAvailableMsg);
+        }
+    }
 
     /// <inheritdoc/>
-    public double Y => BaseBotInternals.CurrentTickOrThrow.BotState.Y;
+    public double Y
+    {
+        get
+        {
+            var tick = BaseBotInternals.CurrentTickOrNull;
+            if (tick != null) return tick.BotState.Y;
+            var initialPosition = BaseBotInternals.InitialPosition;
+            if (initialPosition?.Y != null) return initialPosition.Y.Value;
+            throw new BotException(BaseBotInternals.TickNotAvailableMsg);
+        }
+    }
 
     /// <inheritdoc/>
-    public double Direction => BaseBotInternals.CurrentTickOrThrow.BotState.Direction;
+    public double Direction
+    {
+        get
+        {
+            var tick = BaseBotInternals.CurrentTickOrNull;
+            if (tick != null) return tick.BotState.Direction;
+            var initialPosition = BaseBotInternals.InitialPosition;
+            if (initialPosition?.Direction != null) return initialPosition.Direction.Value;
+            throw new BotException(BaseBotInternals.TickNotAvailableMsg);
+        }
+    }
 
     /// <inheritdoc/>
-    public double GunDirection => BaseBotInternals.CurrentTickOrThrow.BotState.GunDirection;
+    public double GunDirection
+    {
+        get
+        {
+            var tick = BaseBotInternals.CurrentTickOrNull;
+            if (tick != null) return tick.BotState.GunDirection;
+            var initialPosition = BaseBotInternals.InitialPosition;
+            if (initialPosition?.Direction != null) return initialPosition.Direction.Value;
+            throw new BotException(BaseBotInternals.TickNotAvailableMsg);
+        }
+    }
 
     /// <inheritdoc/>
-    public double RadarDirection => BaseBotInternals.CurrentTickOrThrow.BotState.RadarDirection;
+    public double RadarDirection
+    {
+        get
+        {
+            var tick = BaseBotInternals.CurrentTickOrNull;
+            if (tick != null) return tick.BotState.RadarDirection;
+            var initialPosition = BaseBotInternals.InitialPosition;
+            if (initialPosition?.Direction != null) return initialPosition.Direction.Value;
+            throw new BotException(BaseBotInternals.TickNotAvailableMsg);
+        }
+    }
 
     /// <inheritdoc/>
     public double Speed => BaseBotInternals.Speed;

--- a/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
+++ b/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
@@ -29,7 +29,7 @@ sealed class BaseBotInternals
     private const string GameNotRunningMsg =
         "Game is not running. Make sure OnGameStarted() event handler has been called first";
 
-    private const string TickNotAvailableMsg =
+    internal const string TickNotAvailableMsg =
         "Game is not running or tick has not occurred yet. Make sure OnTick() event handler has been called first";
 
     private readonly string _serverSecret;
@@ -209,7 +209,10 @@ sealed class BaseBotInternals
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine(e);
+            // Report unexpected errors from Run(), but stay silent once this thread has been
+            // superseded - the failure is then just fallout from losing the round.
+            if (botThread == _thread)
+                Console.Error.WriteLine(e);
         }
 
         if (botThread != _thread)
@@ -565,6 +568,8 @@ sealed class BaseBotInternals
     internal E.TickEvent CurrentTickOrThrow => _tickEvent ?? throw new BotException(TickNotAvailableMsg);
 
     internal E.TickEvent CurrentTickOrNull => _tickEvent;
+
+    internal InitialPosition InitialPosition => _initialPosition;
 
     internal int TimeLeft
     {

--- a/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
+++ b/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
@@ -184,7 +184,12 @@ sealed class BaseBotInternals
     private void CreateRunnable(IBot bot)
     {
         var botThread = Thread.CurrentThread;
-        IsRunning = true;
+        lock (_threadControlMonitor)
+        {
+            if (botThread != _thread)
+                return;
+            IsRunning = true;
+        }
         try
         {
             // Block until the first tick arrives so Run() can safely access bot state
@@ -259,9 +264,8 @@ sealed class BaseBotInternals
 
         if (currentThread != null && currentThread != Thread.CurrentThread)
         {
-            // Wait for the old bot thread to exit before a new round starts. Without this, a stale
-            // thread can survive a connected restart long enough to send one last turn-1 intent into
-            // the next game before the replacement thread takes over.
+            // Best-effort cleanup only. Ownership was invalidated above, so correctness does
+            // not depend on this bounded wait and an infinite legacy loop cannot block a round.
             currentThread.Join(1000);
         }
     }
@@ -491,6 +495,9 @@ sealed class BaseBotInternals
 
     internal void DispatchEvents(int turnNumber)
     {
+        if (IsRunning && _thread != null && Thread.CurrentThread != _thread)
+            throw new ThreadInterruptedException();
+
         try
         {
             _eventQueue.DispatchEvents(turnNumber);

--- a/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
+++ b/bot-api/dotnet/api/src/internal/BaseBotInternals.cs
@@ -49,10 +49,12 @@ sealed class BaseBotInternals
 
     private readonly EventQueue _eventQueue;
 
+    private const int ThreadJoinTimeoutMillis = 1000;
+
     private readonly object _nextTurnMonitor = new();
     private readonly object _threadControlMonitor = new();
 
-    private Thread _thread;
+    private volatile Thread _thread;
 
     private bool _isRunning;
     private readonly object _isRunningLock = new();
@@ -173,12 +175,13 @@ sealed class BaseBotInternals
 
     internal void StartThread(IBot bot)
     {
+        EnableEventHandling(true); // reset on WebSocket thread — before new bot thread starts
+        var newThread = new Thread(() => CreateRunnable(bot));
         lock (_threadControlMonitor)
         {
-            EnableEventHandling(true); // reset on WebSocket thread — before new bot thread starts
-            _thread = new Thread(() => CreateRunnable(bot));
-            _thread.Start();
+            _thread = newThread;
         }
+        newThread.Start();
     }
 
     private void CreateRunnable(IBot bot)
@@ -236,44 +239,68 @@ sealed class BaseBotInternals
         if (Thread.CurrentThread != _thread)
             return;
 
+        FlushFinalTurnEvents();
+    }
+
+    /// <summary>
+    /// Drains any events still queued for the current tick. Called on the WebSocket thread after
+    /// StopThread() has invalidated bot-thread ownership, so the bot thread can no longer drain
+    /// them itself. Without this, final-tick events would be lost on game-ended, game-aborted and
+    /// disconnected.
+    /// </summary>
+    internal void FlushFinalTurnEvents()
+    {
         var tick = CurrentTickOrNull;
         if (tick != null)
             DispatchEvents(tick.TurnNumber);
     }
 
+    internal void AddEventsFromTick(E.TickEvent tickEvent) => _eventQueue.AddEventsFromTick(tickEvent);
+
     internal void AddEvent(E.BotEvent botEvent) => _eventQueue.AddEvent(botEvent);
 
     internal void StopThread()
     {
-        Thread currentThread;
+        Thread oldThread;
         lock (_threadControlMonitor)
         {
             if (!IsRunning && _thread == null)
                 return;
 
+            oldThread = _thread;
+            _thread = null; // invalidate ownership before waking the old thread
             IsRunning = false;
-            EnableEventHandling(false); // disable on WebSocket thread — prevents new ticks from queuing after bot stops
-
-            currentThread = _thread;
-            if (currentThread != null)
-            {
-                _thread = null; // invalidate ownership immediately so the old thread cannot send another intent
-                currentThread.Interrupt();
-            }
         }
 
-        if (currentThread != null && currentThread != Thread.CurrentThread)
+        EnableEventHandling(false); // disable on WebSocket thread — prevents new ticks from queuing after bot stops
+
+        oldThread?.Interrupt();
+
+        lock (_nextTurnMonitor)
+        {
+            Monitor.PulseAll(_nextTurnMonitor);
+        }
+
+        if (oldThread != null && oldThread != Thread.CurrentThread)
         {
             // Best-effort cleanup only. Ownership was invalidated above, so correctness does
             // not depend on this bounded wait and an infinite legacy loop cannot block a round.
-            currentThread.Join(1000);
+            oldThread.Join(ThreadJoinTimeoutMillis);
         }
     }
 
 
     public void EnableEventHandling(bool enable)
     {
-        _eventHandlingDisabledTurn = enable ? 0 : CurrentTickOrThrow.TurnNumber;
+        if (enable)
+        {
+            _eventHandlingDisabledTurn = 0;
+        }
+        else
+        {
+            var tick = CurrentTickOrNull;
+            _eventHandlingDisabledTurn = tick?.TurnNumber ?? 0;
+        }
     }
 
     private bool IsEventHandlingDisabled()
@@ -482,7 +509,7 @@ sealed class BaseBotInternals
     {
         lock (_nextTurnMonitor)
         {
-            while (IsRunning && CurrentTickOrNull == null)
+            while (IsRunning && Thread.CurrentThread == _thread && CurrentTickOrNull == null)
             {
                 Monitor.Wait(_nextTurnMonitor);
             }
@@ -836,7 +863,11 @@ sealed class BaseBotInternals
         var disconnectedEvent = new E.DisconnectedEvent(_socket.ServerUri, remote, statusCode, reason);
 
         BotEventHandlers.OnDisconnected.Publish(disconnectedEvent);
-        InternalEventHandlers.OnDisconnected.Publish(disconnectedEvent);
+        InternalEventHandlers.OnDisconnected.Publish(disconnectedEvent); // triggers StopThread()
+
+        // The bot thread no longer owns the round after StopThread(), so drain its final-tick
+        // events here — otherwise they are lost.
+        FlushFinalTurnEvents();
 
         RestoreStdOutAndStdErr();
         _closedEvent.Set();
@@ -911,7 +942,7 @@ sealed class BaseBotInternals
         _ticksStart = Stopwatch.GetTimestamp();
 
         var mappedTickEvent = EventMapper.Map(json, _baseBot);
-        _eventQueue.AddEventsFromTick(mappedTickEvent);
+        AddEventsFromTick(mappedTickEvent);
 
         _tickEvent = mappedTickEvent;
 
@@ -1001,13 +1032,17 @@ sealed class BaseBotInternals
         var mappedGameEnded = new E.GameEndedEvent(gameEndedEventForBot.NumberOfRounds, results);
 
         BotEventHandlers.OnGameEnded.Publish(mappedGameEnded);
-        InternalEventHandlers.OnGameEnded.Publish(mappedGameEnded);
+        InternalEventHandlers.OnGameEnded.Publish(mappedGameEnded); // triggers StopThread()
+
+        FlushFinalTurnEvents();
     }
 
     private void HandleGameAborted()
     {
         BotEventHandlers.OnGameAborted.Publish(null);
-        InternalEventHandlers.OnGameAborted.Publish(null);
+        InternalEventHandlers.OnGameAborted.Publish(null); // triggers StopThread()
+
+        FlushFinalTurnEvents();
     }
 
     private void HandleSkippedTurn(string json)

--- a/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
+++ b/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using Robocode.TankRoyale.BotApi.Events;
+using Robocode.TankRoyale.BotApi.Internal;
+
+namespace Robocode.TankRoyale.BotApi.Tests.Internal;
+
+/// <summary>
+/// Round-ownership lifecycle tests, the .NET twin of the Java
+/// BaseBotInternalsLifecycleTest and the Python test_round_lifecycle.py.
+/// </summary>
+[TestFixture]
+[Category("BOT")]
+public class BaseBotInternalsLifecycleTest
+{
+    private class TestBot : BaseBot
+    {
+        public int DispatchedTicks { get; private set; }
+
+        public TestBot() : base(new BotInfo("LifecycleTest", "1.0", new List<string> { "Test" },
+            null, null, null, new HashSet<string> { "classic" }, null, null, null))
+        {
+        }
+
+        public override void OnTick(TickEvent e) => DispatchedTicks++;
+    }
+
+    private static void SetTickEvent(BaseBotInternals internals, TickEvent tick)
+    {
+        var field = typeof(BaseBotInternals).GetField("_tickEvent", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(internals, tick);
+    }
+
+    private static void SetThread(BaseBotInternals internals, Thread thread)
+    {
+        var field = typeof(BaseBotInternals).GetField("_thread", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(internals, thread);
+    }
+
+    private static void SetRunning(BaseBotInternals internals, bool running)
+    {
+        var property = typeof(BaseBotInternals).GetProperty("IsRunning",
+            BindingFlags.Public | BindingFlags.Instance);
+        property!.SetValue(internals, running);
+    }
+
+    [Test]
+    public void StaleThreadCannotDispatchAfterNextRoundTakesOwnership()
+    {
+        var internals = new TestBot().BaseBotInternals;
+        SetRunning(internals, true);
+
+        // The round is owned by some other thread — this one is stale.
+        SetThread(internals, new Thread(() => { }));
+
+        Assert.Throws<ThreadInterruptedException>(() => internals.DispatchEvents(1));
+    }
+
+    [Test]
+    public void FinalTickEventsAreFlushedAfterTheBotThreadLosesOwnership()
+    {
+        var bot = new TestBot();
+        var internals = bot.BaseBotInternals;
+
+        var tick = new TickEvent(1, 1, null, new List<BulletState>(), new List<BotEvent>());
+        SetTickEvent(internals, tick);
+        internals.AddEventsFromTick(tick);
+
+        // StopThread() invalidates bot-thread ownership, so the bot thread can no longer drain
+        // the queue itself. The WebSocket thread must still be able to — this is what the
+        // game-ended, game-aborted and disconnected paths rely on.
+        internals.StopThread();
+        internals.FlushFinalTurnEvents();
+
+        Assert.That(bot.DispatchedTicks, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void StopThreadDoesNotThrowBeforeTheFirstTickOfARound()
+    {
+        var internals = new TestBot().BaseBotInternals;
+        SetRunning(internals, true);
+
+        // No tick has arrived yet. EnableEventHandling(false) must not throw here, otherwise
+        // StopThread() aborts and leaves a stale thread owning the round.
+        Assert.DoesNotThrow(() => internals.StopThread());
+        Assert.That(internals.IsRunning, Is.False);
+    }
+}

--- a/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
+++ b/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
@@ -70,6 +70,8 @@ public class BaseBotInternalsLifecycleTest
     }
 
     [Test]
+    [Category("TCK")]
+    [Category("TR-API-TCK-018")]
     public void StaleThreadCannotDispatchAfterNextRoundTakesOwnership()
     {
         var internals = new TestBot().BaseBotInternals;
@@ -82,6 +84,8 @@ public class BaseBotInternalsLifecycleTest
     }
 
     [Test]
+    [Category("TCK")]
+    [Category("TR-API-TCK-019")]
     public void FinalTickEventsAreFlushedAfterTheBotThreadLosesOwnership()
     {
         var bot = new TestBot();
@@ -116,6 +120,8 @@ public class BaseBotInternalsLifecycleTest
     }
 
     [Test]
+    [Category("TCK")]
+    [Category("TR-API-TCK-020")]
     public void UnexpectedErrorFromRunStillDrainsFinalTurnEvents()
     {
         var bot = new TestBot();

--- a/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
+++ b/bot-api/dotnet/test/src/internal/BaseBotInternalsLifecycleTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
@@ -25,6 +26,28 @@ public class BaseBotInternalsLifecycleTest
         }
 
         public override void OnTick(TickEvent e) => DispatchedTicks++;
+    }
+
+    /// <summary>
+    /// Minimal IBot proxy: Run() throws, every other member is a harmless default. Mirrors the
+    /// java.lang.reflect.Proxy stub the Java lifecycle test uses.
+    /// </summary>
+    public class ExplodingBotProxy : DispatchProxy
+    {
+        protected override object Invoke(MethodInfo targetMethod, object[] args)
+        {
+            if (targetMethod!.Name == nameof(IBot.Run))
+                throw new InvalidOperationException("boom");
+
+            // End the post-run() pre-warm loop on the first Go(), the way a stopped bot does.
+            // Letting it spin allocates per call and can exhaust the test host.
+            if (targetMethod.Name == nameof(IBot.Go))
+                throw new ThreadInterruptedException();
+
+            var returnType = targetMethod.ReturnType;
+            if (returnType == typeof(void) || !returnType.IsValueType) return null;
+            return Activator.CreateInstance(returnType);
+        }
     }
 
     private static void SetTickEvent(BaseBotInternals internals, TickEvent tick)
@@ -75,6 +98,50 @@ public class BaseBotInternalsLifecycleTest
         internals.FlushFinalTurnEvents();
 
         Assert.That(bot.DispatchedTicks, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void WaitForNextTurnUnwindsWhenNoThreadOwnsTheRound()
+    {
+        var internals = new TestBot().BaseBotInternals;
+        SetTickEvent(internals, new TickEvent(1, 1, null, new List<BulletState>(), new List<BotEvent>()));
+
+        // A BaseBot with no Run() loop owns no thread, so the blocking wait unwinds right after
+        // the intent was sent by Execute(). Mirrored by the Java and Python lifecycle tests.
+        var waitForNextTurn = typeof(BaseBotInternals).GetMethod("WaitForNextTurn",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        var ex = Assert.Throws<TargetInvocationException>(() => waitForNextTurn!.Invoke(internals, new object[] { 1 }));
+        Assert.That(ex.InnerException, Is.InstanceOf<ThreadInterruptedException>());
+    }
+
+    [Test]
+    public void UnexpectedErrorFromRunStillDrainsFinalTurnEvents()
+    {
+        var bot = new TestBot();
+        var internals = bot.BaseBotInternals;
+
+        var tick = new TickEvent(1, 1, null, new List<BulletState>(), new List<BotEvent>());
+        SetTickEvent(internals, tick);
+        internals.AddEventsFromTick(tick);
+
+        // Run() blowing up must not cost the bot its final-turn events.
+        internals.StartThread(DispatchProxy.Create<IBot, ExplodingBotProxy>());
+
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        try
+        {
+            while (bot.DispatchedTicks == 0 && DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(5);
+            }
+        }
+        finally
+        {
+            internals.StopThread();
+        }
+
+        Assert.That(bot.DispatchedTicks, Is.GreaterThanOrEqualTo(1));
     }
 
     [Test]

--- a/bot-api/dotnet/test/src/internal/SharedTestRunner.cs
+++ b/bot-api/dotnet/test/src/internal/SharedTestRunner.cs
@@ -283,9 +283,23 @@ public class SharedTestRunner
         _ => throw new ArgumentException($"Unknown event for scenario: {eventName}")
     };
 
+    private static void ApplyInitialPositionSetup(BaseBot bot, TestCase testCase)
+    {
+        if (testCase.Setup == null || !testCase.Setup.TryGetValue("initialPosition", out var raw)) return;
+
+        var values = JsonConvert.DeserializeObject<Dictionary<string, double?>>(raw.ToString() ?? "{}");
+        var initialPosition = new InitialPosition(
+            values.GetValueOrDefault("x"), values.GetValueOrDefault("y"), values.GetValueOrDefault("direction"));
+
+        var field = typeof(BaseBotInternals).GetField("_initialPosition",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(bot.BaseBotInternals, initialPosition);
+    }
+
     private void ExecuteBotDefault(TestCase testCase)
     {
         var bot = new BotDefaultStub();
+        ApplyInitialPositionSetup(bot, testCase);
         Func<object> callMethod = testCase.Method switch
         {
             "getMyId"                  => () => bot.MyId,

--- a/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/BaseBot.java
+++ b/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/BaseBot.java
@@ -287,7 +287,7 @@ public abstract class BaseBot implements IBaseBot {
             return tick.getBotState().getX();
         }
         var initialPosition = baseBotInternals.getInitialPosition();
-        if (initialPosition != null) {
+        if (initialPosition != null && initialPosition.getX() != null) {
             return initialPosition.getX();
         }
         throw new BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first");
@@ -303,7 +303,7 @@ public abstract class BaseBot implements IBaseBot {
             return tick.getBotState().getY();
         }
         var initialPosition = baseBotInternals.getInitialPosition();
-        if (initialPosition != null) {
+        if (initialPosition != null && initialPosition.getY() != null) {
             return initialPosition.getY();
         }
         throw new BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first");
@@ -319,7 +319,7 @@ public abstract class BaseBot implements IBaseBot {
             return tick.getBotState().getDirection();
         }
         var initialPosition = baseBotInternals.getInitialPosition();
-        if (initialPosition != null) {
+        if (initialPosition != null && initialPosition.getDirection() != null) {
             return initialPosition.getDirection();
         }
         throw new BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first");
@@ -335,7 +335,7 @@ public abstract class BaseBot implements IBaseBot {
             return tick.getBotState().getGunDirection();
         }
         var initialPosition = baseBotInternals.getInitialPosition();
-        if (initialPosition != null) {
+        if (initialPosition != null && initialPosition.getDirection() != null) {
             return initialPosition.getDirection();
         }
         throw new BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first");
@@ -351,7 +351,7 @@ public abstract class BaseBot implements IBaseBot {
             return tick.getBotState().getRadarDirection();
         }
         var initialPosition = baseBotInternals.getInitialPosition();
-        if (initialPosition != null) {
+        if (initialPosition != null && initialPosition.getDirection() != null) {
             return initialPosition.getDirection();
         }
         throw new BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first");

--- a/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternals.java
+++ b/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternals.java
@@ -70,7 +70,8 @@ public final class BaseBotInternals {
 
     private final Object nextTurnMonitor = new Object();
 
-    private Thread thread;
+    private volatile Thread thread;
+    private final Object threadControlMonitor = new Object();
 
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private boolean isStopped;
@@ -145,25 +146,42 @@ public final class BaseBotInternals {
 
     void startThread(IBot bot) {
         enableEventHandling(true); // reset on WebSocket thread — before new bot thread starts
-        thread = new Thread(createRunnable(bot));
-        thread.start();
+        var newThread = new Thread(createRunnable(bot));
+        synchronized (threadControlMonitor) {
+            thread = newThread;
+        }
+        newThread.start();
     }
 
     private Runnable createRunnable(IBot bot) {
         return () -> {
-            setRunning(true);
+            var botThread = Thread.currentThread();
+            synchronized (threadControlMonitor) {
+                if (botThread != thread) {
+                    return;
+                }
+                setRunning(true);
+            }
             try {
                 waitUntilFirstTickArrived();
+                if (botThread != thread) {
+                    return;
+                }
                 bot.run();
             } catch (ThreadInterruptedException e) {
             } catch (Throwable t) {
-                t.printStackTrace();
+                if (botThread == thread) {
+                    t.printStackTrace();
+                }
             }
 
-            dispatchFinalTurnEvents();
+            if (botThread != thread) {
+                return;
+            }
+            dispatchFinalTurnEvents(botThread);
 
             // Skip every turn after the run method has exited
-            while (isRunning()) {
+            while (isRunning() && botThread == thread) {
                 try {
                     bot.go();
                 } catch (ThreadInterruptedException ignored) {
@@ -171,11 +189,16 @@ public final class BaseBotInternals {
                 }
             }
 
-            dispatchFinalTurnEvents();
+            if (botThread == thread) {
+                dispatchFinalTurnEvents(botThread);
+            }
         };
     }
 
-    private void dispatchFinalTurnEvents() {
+    private void dispatchFinalTurnEvents(Thread botThread) {
+        if (botThread != thread) {
+            return;
+        }
         var tick = getCurrentTickOrNull();
         if (tick != null) {
             dispatchEvents(tick.getTurnNumber());
@@ -183,15 +206,24 @@ public final class BaseBotInternals {
     }
 
     void stopThread() {
-        if (!isRunning())
-            return;
+        Thread oldThread;
+        synchronized (threadControlMonitor) {
+            if (!isRunning() && thread == null) {
+                return;
+            }
 
-        setRunning(false);
+            oldThread = thread;
+            thread = null; // invalidate ownership before waking the old thread
+            setRunning(false);
+        }
+
         enableEventHandling(false); // disable on WebSocket thread — prevents new ticks from queuing after bot stops
 
-        if (thread != null) {
-            thread.interrupt();
-            thread = null;
+        if (oldThread != null) {
+            oldThread.interrupt();
+        }
+        synchronized (nextTurnMonitor) {
+            nextTurnMonitor.notifyAll();
         }
     }
 
@@ -413,7 +445,7 @@ public final class BaseBotInternals {
     // (priority 110) has already captured the initial directions via clearRemaining().
     private void waitUntilFirstTickArrived() {
         synchronized (nextTurnMonitor) {
-            while (isRunning() && getCurrentTickOrNull() == null) {
+            while (isRunning() && Thread.currentThread() == thread && getCurrentTickOrNull() == null) {
                 try {
                     nextTurnMonitor.wait();
                 } catch (InterruptedException ex) {
@@ -434,6 +466,9 @@ public final class BaseBotInternals {
     }
 
     public void dispatchEvents(int turnNumber) {
+        if (isRunning() && thread != null && Thread.currentThread() != thread) {
+            throw new ThreadInterruptedException();
+        }
         try {
             eventQueue.dispatchEvents(turnNumber);
         } catch (Exception e) {

--- a/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternals.java
+++ b/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternals.java
@@ -70,6 +70,8 @@ public final class BaseBotInternals {
 
     private final Object nextTurnMonitor = new Object();
 
+    private static final long THREAD_JOIN_TIMEOUT_MILLIS = 1000;
+
     private volatile Thread thread;
     private final Object threadControlMonitor = new Object();
 
@@ -199,6 +201,16 @@ public final class BaseBotInternals {
         if (botThread != thread) {
             return;
         }
+        flushFinalTurnEvents();
+    }
+
+    /**
+     * Drains any events still queued for the current tick. Called on the WebSocket thread after
+     * stopThread() has invalidated bot-thread ownership, so the bot thread can no longer drain
+     * them itself. Without this, final-tick events would be lost on game-ended, game-aborted and
+     * disconnected.
+     */
+    void flushFinalTurnEvents() {
         var tick = getCurrentTickOrNull();
         if (tick != null) {
             dispatchEvents(tick.getTurnNumber());
@@ -224,6 +236,16 @@ public final class BaseBotInternals {
         }
         synchronized (nextTurnMonitor) {
             nextTurnMonitor.notifyAll();
+        }
+
+        if (oldThread != null && oldThread != Thread.currentThread()) {
+            // Best-effort cleanup only. Ownership was invalidated above, so correctness does not
+            // depend on this bounded wait and an infinite legacy loop cannot block a round.
+            try {
+                oldThread.join(THREAD_JOIN_TIMEOUT_MILLIS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/WebSocketHandler.java
+++ b/bot-api/java/src/main/java/dev/robocode/tankroyale/botapi/internal/WebSocketHandler.java
@@ -77,7 +77,11 @@ final class WebSocketHandler implements WebSocket.Listener {
         var disconnectedEvent = new DisconnectedEvent(serverUrl, true, statusCode, reason);
 
         botEventHandlers.onDisconnected.publish(disconnectedEvent);
-        internalEventHandlers.onDisconnected.publish(disconnectedEvent);
+        internalEventHandlers.onDisconnected.publish(disconnectedEvent); // triggers stopThread()
+
+        // The bot thread no longer owns the round after stopThread(), so drain its final-tick
+        // events here — otherwise they are lost.
+        baseBotInternals.flushFinalTurnEvents();
 
         closedLatch.countDown();
         return null;
@@ -223,12 +227,16 @@ final class WebSocketHandler implements WebSocket.Listener {
                 map(gameEndedEventForBot.getResults()));
 
         botEventHandlers.onGameEnded.publish(mappedGameEnded);
-        internalEventHandlers.onGameEnded.publish(mappedGameEnded);
+        internalEventHandlers.onGameEnded.publish(mappedGameEnded); // triggers stopThread()
+
+        baseBotInternals.flushFinalTurnEvents();
     }
 
     private void handleGameAborted() {
         botEventHandlers.onGameAborted.publish(null);
-        internalEventHandlers.onGameAborted.publish(null);
+        internalEventHandlers.onGameAborted.publish(null); // triggers stopThread()
+
+        baseBotInternals.flushFinalTurnEvents();
     }
 
     private void handleSkippedTurn(JsonObject jsonMsg) {

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/BaseBotStateTest.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/BaseBotStateTest.java
@@ -50,6 +50,21 @@ class BaseBotStateTest {
     }
 
     @Test
+    @Tag("TR-API-BOT-007")
+    void test_TR_API_BOT_007_null_initial_position_components_do_not_unbox() throws Exception {
+        var bot = new TestBot();
+        var setter = bot.baseBotInternals.getClass().getDeclaredMethod("setInitialPosition", InitialPosition.class);
+        setter.setAccessible(true);
+        setter.invoke(bot.baseBotInternals, new InitialPosition(null, null, null));
+
+        assertThrows(BotException.class, bot::getX);
+        assertThrows(BotException.class, bot::getY);
+        assertThrows(BotException.class, bot::getDirection);
+        assertThrows(BotException.class, bot::getGunDirection);
+        assertThrows(BotException.class, bot::getRadarDirection);
+    }
+
+    @Test
     @Tag("TR-API-BOT-008")
     @Tag("LEGACY")
     void test_TR_API_BOT_008_adjustment_flags_default_false() {

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
@@ -4,6 +4,7 @@ import dev.robocode.tankroyale.botapi.BotInfo;
 import dev.robocode.tankroyale.botapi.IBot;
 import dev.robocode.tankroyale.botapi.IBaseBot;
 import dev.robocode.tankroyale.botapi.events.TickEvent;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
@@ -19,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class BaseBotInternalsLifecycleTest {
 
     @Test
+    @Tag("TCK")
+    @Tag("TR-API-TCK-018")
     void stale_bot_thread_cannot_dispatch_after_next_round_takes_ownership() throws Exception {
         var internals = new BaseBotInternals(proxy(IBaseBot.class), botInfo(), null, null);
         internals.setTickEvent(new TickEvent(1, 1, null, List.of(), List.of()));
@@ -66,6 +69,8 @@ class BaseBotInternalsLifecycleTest {
     }
 
     @Test
+    @Tag("TCK")
+    @Tag("TR-API-TCK-019")
     void final_tick_events_are_flushed_after_the_bot_thread_loses_ownership() {
         var dispatchedTicks = new AtomicInteger();
         var baseBot = (IBaseBot) Proxy.newProxyInstance(
@@ -107,6 +112,8 @@ class BaseBotInternalsLifecycleTest {
     }
 
     @Test
+    @Tag("TCK")
+    @Tag("TR-API-TCK-020")
     void unexpected_error_from_run_still_drains_final_turn_events() throws Exception {
         var dispatchedTicks = new AtomicInteger();
         var baseBot = (IBaseBot) Proxy.newProxyInstance(

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,6 +62,33 @@ class BaseBotInternalsLifecycleTest {
         internals.stopThread();
 
         assertThat(staleDispatchBlocked).isTrue();
+    }
+
+    @Test
+    void final_tick_events_are_flushed_after_the_bot_thread_loses_ownership() {
+        var dispatchedTicks = new AtomicInteger();
+        var baseBot = (IBaseBot) Proxy.newProxyInstance(
+                IBaseBot.class.getClassLoader(),
+                new Class<?>[]{IBaseBot.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("onTick")) {
+                        dispatchedTicks.incrementAndGet();
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        var internals = new BaseBotInternals(baseBot, botInfo(), null, null);
+        var tick = new TickEvent(1, 1, null, List.of(), List.of());
+        internals.setTickEvent(tick);
+        internals.addEventsFromTick(tick);
+
+        // stopThread() invalidates bot-thread ownership, so the bot thread can no longer drain
+        // the queue itself. The WebSocket thread must still be able to — this is what the
+        // game-ended, game-aborted and disconnected paths rely on.
+        internals.stopThread();
+        internals.flushFinalTurnEvents();
+
+        assertThat(dispatchedTicks).hasValue(1);
     }
 
     private static BotInfo botInfo() {

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
@@ -1,0 +1,105 @@
+package dev.robocode.tankroyale.botapi.internal;
+
+import dev.robocode.tankroyale.botapi.BotInfo;
+import dev.robocode.tankroyale.botapi.IBot;
+import dev.robocode.tankroyale.botapi.IBaseBot;
+import dev.robocode.tankroyale.botapi.events.TickEvent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BaseBotInternalsLifecycleTest {
+
+    @Test
+    void stale_bot_thread_cannot_dispatch_after_next_round_takes_ownership() throws Exception {
+        var internals = new BaseBotInternals(proxy(IBaseBot.class), botInfo(), null, null);
+        internals.setTickEvent(new TickEvent(1, 1, null, List.of(), List.of()));
+
+        var entered = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var staleDispatchBlocked = new AtomicBoolean(false);
+        var oldBot = botProxy((method, args) -> {
+            if (method.getName().equals("run")) {
+                entered.countDown();
+                while (release.getCount() != 0) {
+                    try {
+                        release.await(20, TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException ignored) {
+                        // Keep the legacy bot alive until the test releases it.
+                    }
+                }
+                try {
+                    internals.dispatchEvents(1);
+                } catch (ThreadInterruptedException expected) {
+                    staleDispatchBlocked.set(true);
+                }
+            }
+            return defaultValue(method.getReturnType());
+        });
+
+        internals.startThread(oldBot);
+        assertThat(entered.await(2, TimeUnit.SECONDS)).isTrue();
+
+        internals.stopThread();
+        internals.startThread(botProxy((method, args) -> defaultValue(method.getReturnType())));
+        long runningDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!internals.isRunning() && System.nanoTime() < runningDeadline) {
+            Thread.sleep(5);
+        }
+        release.countDown();
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!staleDispatchBlocked.get() && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        internals.stopThread();
+
+        assertThat(staleDispatchBlocked).isTrue();
+    }
+
+    private static BotInfo botInfo() {
+        return BotInfo.builder()
+                .setName("LifecycleTest")
+                .setVersion("1.0")
+                .addAuthor("Test")
+                .addGameType("classic")
+                .build();
+    }
+
+    private static <T> T proxy(Class<T> type) {
+        return type.cast(Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[]{type},
+                (proxy, method, args) -> defaultValue(method.getReturnType())));
+    }
+
+    private static IBot botProxy(Invocation invocation) {
+        return IBot.class.cast(Proxy.newProxyInstance(
+                IBot.class.getClassLoader(),
+                new Class<?>[]{IBot.class},
+                (proxy, method, args) -> invocation.call(method, args)));
+    }
+
+    private interface Invocation {
+        Object call(java.lang.reflect.Method method, Object[] args);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == byte.class) return (byte) 0;
+        if (type == short.class) return (short) 0;
+        if (type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0f;
+        if (type == double.class) return 0d;
+        if (type == char.class) return '\0';
+        return null;
+    }
+}

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/BaseBotInternalsLifecycleTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BaseBotInternalsLifecycleTest {
 
@@ -89,6 +90,60 @@ class BaseBotInternalsLifecycleTest {
         internals.flushFinalTurnEvents();
 
         assertThat(dispatchedTicks).hasValue(1);
+    }
+
+    @Test
+    void wait_for_next_turn_unwinds_when_no_thread_owns_the_round() throws Exception {
+        var internals = new BaseBotInternals(proxy(IBaseBot.class), botInfo(), null, null);
+        internals.setTickEvent(new TickEvent(1, 1, null, List.of(), List.of()));
+
+        // A BaseBot with no run() loop owns no thread, so the blocking wait unwinds right after
+        // the intent was sent by execute(). Mirrored by the .NET and Python lifecycle tests.
+        var waitForNextTurn = BaseBotInternals.class.getDeclaredMethod("waitForNextTurn", int.class);
+        waitForNextTurn.setAccessible(true);
+
+        assertThatThrownBy(() -> waitForNextTurn.invoke(internals, 1))
+                .hasCauseInstanceOf(ThreadInterruptedException.class);
+    }
+
+    @Test
+    void unexpected_error_from_run_still_drains_final_turn_events() throws Exception {
+        var dispatchedTicks = new AtomicInteger();
+        var baseBot = (IBaseBot) Proxy.newProxyInstance(
+                IBaseBot.class.getClassLoader(),
+                new Class<?>[]{IBaseBot.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("onTick")) {
+                        dispatchedTicks.incrementAndGet();
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        var internals = new BaseBotInternals(baseBot, botInfo(), null, null);
+        var tick = new TickEvent(1, 1, null, List.of(), List.of());
+        internals.setTickEvent(tick);
+        internals.addEventsFromTick(tick);
+
+        // run() blowing up must not cost the bot its final-turn events.
+        internals.startThread(botProxy((method, args) -> {
+            if (method.getName().equals("run")) {
+                throw new IllegalStateException("boom");
+            }
+            // End the post-run() pre-warm loop on the first go(), the way a stopped bot does.
+            // Letting it spin burns CPU and allocates for the whole wait below.
+            if (method.getName().equals("go")) {
+                throw new ThreadInterruptedException();
+            }
+            return defaultValue(method.getReturnType());
+        }));
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (dispatchedTicks.get() == 0 && System.nanoTime() < deadline) {
+            Thread.sleep(5);
+        }
+        internals.stopThread();
+
+        assertThat(dispatchedTicks.get()).isGreaterThanOrEqualTo(1);
     }
 
     private static BotInfo botInfo() {

--- a/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/SharedTestRunner.java
+++ b/bot-api/java/src/test/java/dev/robocode/tankroyale/botapi/internal/SharedTestRunner.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import dev.robocode.tankroyale.botapi.IBaseBot;
 import dev.robocode.tankroyale.botapi.BaseBot;
+import dev.robocode.tankroyale.botapi.InitialPosition;
 import dev.robocode.tankroyale.botapi.BotException;
 import dev.robocode.tankroyale.botapi.BulletState;
 import dev.robocode.tankroyale.botapi.BotInfo;
@@ -379,6 +380,7 @@ public class SharedTestRunner {
 
     private void executeBotDefault(TestCase testCase) {
         BaseBot bot = new BotDefaultStub();
+        applyInitialPositionSetup(bot, testCase);
         if (testCase.expected.containsKey("throws")) {
             assertThrows(BotException.class, () -> callBotDefaultMethod(bot, testCase.method));
         } else {
@@ -394,6 +396,27 @@ public class SharedTestRunner {
                 assertThat((Collection<?>) result).isEmpty();
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void applyInitialPositionSetup(BaseBot bot, TestCase testCase) {
+        if (testCase.setup == null || !testCase.setup.containsKey("initialPosition")) return;
+        var values = (Map<String, Object>) testCase.setup.get("initialPosition");
+        var initialPosition = new InitialPosition(
+                toDouble(values.get("x")), toDouble(values.get("y")), toDouble(values.get("direction")));
+        try {
+            var setter = BaseBotInternals.class.getDeclaredMethod("setInitialPosition", InitialPosition.class);
+            setter.setAccessible(true);
+            var field = BaseBot.class.getDeclaredField("baseBotInternals");
+            field.setAccessible(true);
+            setter.invoke(field.get(bot), initialPosition);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not apply initialPosition setup", e);
+        }
+    }
+
+    private static Double toDouble(Object value) {
+        return value == null ? null : ((Number) value).doubleValue();
     }
 
     private static Object callBotDefaultMethod(BaseBot bot, String method) {

--- a/bot-api/python/src/robocode_tank_royale/bot_api/base_bot.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/base_bot.py
@@ -278,7 +278,7 @@ class BaseBot(BaseBotABC):
         if tick is not None:
             return tick.bot_state.x
         initial_position = self._internals.initial_position
-        if initial_position is not None:
+        if initial_position is not None and initial_position.x is not None:
             return initial_position.x
         raise BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first")
 
@@ -293,7 +293,7 @@ class BaseBot(BaseBotABC):
         if tick is not None:
             return tick.bot_state.y
         initial_position = self._internals.initial_position
-        if initial_position is not None:
+        if initial_position is not None and initial_position.y is not None:
             return initial_position.y
         raise BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first")
 
@@ -308,7 +308,7 @@ class BaseBot(BaseBotABC):
         if tick is not None:
             return tick.bot_state.direction
         initial_position = self._internals.initial_position
-        if initial_position is not None:
+        if initial_position is not None and initial_position.direction is not None:
             return initial_position.direction
         raise BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first")
 
@@ -323,7 +323,7 @@ class BaseBot(BaseBotABC):
         if tick is not None:
             return tick.bot_state.gun_direction
         initial_position = self._internals.initial_position
-        if initial_position is not None:
+        if initial_position is not None and initial_position.direction is not None:
             return initial_position.direction
         raise BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first")
 
@@ -338,7 +338,7 @@ class BaseBot(BaseBotABC):
         if tick is not None:
             return tick.bot_state.radar_direction
         initial_position = self._internals.initial_position
-        if initial_position is not None:
+        if initial_position is not None and initial_position.direction is not None:
             return initial_position.direction
         raise BotException("Game is not running or tick has not occurred yet. Make sure onTick() event handler has been called first")
 

--- a/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
@@ -400,6 +400,11 @@ class BaseBotInternals:
                 bot.run()
             except ThreadInterruptedException:
                 pass
+            except Exception:
+                # Report unexpected errors from run(), but stay silent once this thread has
+                # been superseded - the failure is then just fallout from losing the round.
+                if self.thread is bot_thread:
+                    traceback.print_exc()
 
             if self.thread is not bot_thread:
                 return
@@ -648,20 +653,15 @@ class BaseBotInternals:
 
     def _wait_for_next_turn(self, turn_number: int) -> None:
         """Wait for next turn (matches Java's waitForNextTurn)"""
-        # Check if we're being called from the designated bot thread.
-        # If self.thread is None (test mode with no run() loop), exit immediately - the intent
-        # was already sent in execute() before this call. This allows tests to call go() from
-        # test threads without hanging.
-        if self.thread is None:
-            return
-
         # Most bot methods call _wait_for_next_turn(), so this is the central place to stop a
         # rogue thread that cannot be killed any other way (matches Java's waitForNextTurn).
+        # A BaseBot with no run() loop owns no thread, so this unwinds go() right after the
+        # intent was sent in execute() - the same way Java and .NET behave.
         self._stop_rogue_thread()
 
-        # Only wait if we're in the correct bot thread and bot is running
+        bot_thread = threading.current_thread()
         with self._next_turn_condition:
-            while self.is_running():
+            while self.is_running() and self.thread is bot_thread:
                 current_tick = self.current_tick_or_null
                 if current_tick is None or current_tick.turn_number != turn_number:
                     break

--- a/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
@@ -46,6 +46,9 @@ from robocode_tank_royale.schema import Message, BotIntent, ServerHandshake, Tea
 
 DEFAULT_SERVER_URL = "ws://localhost:7654"
 
+# Bounded, best-effort wait for a superseded bot thread to exit (matches Java/.NET: 1000 ms).
+THREAD_JOIN_TIMEOUT_SECS = 1.0
+
 GAME_NOT_RUNNING_MSG = (
     "Game is not running. Make sure onGameStarted() event handler has been called first"
 )
@@ -417,6 +420,15 @@ class BaseBotInternals:
         """Dispatch any remaining events from the current tick before the thread exits."""
         if self.thread is not bot_thread:
             return
+        self.flush_final_turn_events()
+
+    def flush_final_turn_events(self) -> None:
+        """Drain any events still queued for the current tick.
+
+        Called on the WebSocket thread after stop_thread() has invalidated bot-thread ownership,
+        so the bot thread can no longer drain them itself. Without this, final-tick events would
+        be lost on game-ended, game-aborted and disconnected.
+        """
         tick = self.current_tick_or_null
         if tick is not None:
             self.dispatch_events(tick.turn_number)
@@ -434,13 +446,21 @@ class BaseBotInternals:
         with self._thread_control_lock:
             if not self.is_running() and self.thread is None:
                 return
-            self.set_running(False)
+            old_thread = self.thread
             self.thread = None  # invalidate ownership before waking the old thread
+            self.set_running(False)
         self.enable_event_handling(False)  # disable on WebSocket thread — prevents new ticks from queuing after bot stops
 
         # Wake up any threads waiting on the next turn condition so they can see is_running=False
         with self._next_turn_condition:
             self._next_turn_condition.notify_all()
+
+        if old_thread is not None and old_thread is not threading.current_thread():
+            # Best-effort cleanup only. Ownership was invalidated above, so correctness does not
+            # depend on this bounded wait and an infinite legacy loop cannot block a round. It
+            # still keeps the old thread from dispatching concurrently with the WebSocket thread
+            # in the common case.
+            old_thread.join(timeout=THREAD_JOIN_TIMEOUT_SECS)
 
 
     def _sanitize_url(self, uri: str) -> None:
@@ -628,15 +648,16 @@ class BaseBotInternals:
 
     def _wait_for_next_turn(self, turn_number: int) -> None:
         """Wait for next turn (matches Java's waitForNextTurn)"""
-        # Check if we're being called from the designated bot thread
-        # If self.thread is None (test mode with no run() loop) or current thread doesn't match,
-        # exit immediately - the intent was already sent in execute() before this call
+        # Check if we're being called from the designated bot thread.
+        # If self.thread is None (test mode with no run() loop), exit immediately - the intent
+        # was already sent in execute() before this call. This allows tests to call go() from
+        # test threads without hanging.
         if self.thread is None:
-            # In test mode or when called from wrong thread, just return without waiting
-            # This allows tests to call go() from test threads without hanging
             return
-        if threading.current_thread() is not self.thread:
-            raise ThreadInterruptedException()
+
+        # Most bot methods call _wait_for_next_turn(), so this is the central place to stop a
+        # rogue thread that cannot be killed any other way (matches Java's waitForNextTurn).
+        self._stop_rogue_thread()
 
         # Only wait if we're in the correct bot thread and bot is running
         with self._next_turn_condition:
@@ -653,7 +674,7 @@ class BaseBotInternals:
 
     def _stop_rogue_thread(self) -> None:
         """Stop rogue thread (matches Java's stopRogueThread)"""
-        if self.is_running() and self.thread is not None and threading.current_thread() is not self.thread:
+        if threading.current_thread() is not self.thread:
             raise ThreadInterruptedException()
 
     def set_fire(self, firepower: float) -> bool:

--- a/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/internal/base_bot_internals.py
@@ -122,6 +122,7 @@ class BaseBotInternals:
 
         # Bot thread (runs bot.run() and bot.go())
         self.thread: Optional[threading.Thread] = None
+        self._thread_control_lock = threading.Lock()
         self.stop_resume_listener: Optional[StopResumeListenerABC] = None
 
         self.max_speed: float = MAX_SPEED
@@ -348,6 +349,8 @@ class BaseBotInternals:
         self.event_queue.set_current_event_interruptible(interruptible)
 
     def dispatch_events(self, turn_number: int) -> None:
+        if self.is_running() and self.thread is not None and threading.current_thread() is not self.thread:
+            raise ThreadInterruptedException()
         try:
             self.event_queue.dispatch_events(turn_number)
         except BotException:
@@ -364,7 +367,7 @@ class BaseBotInternals:
     def is_running(self) -> bool:
         return self._is_running_atomic
 
-    def _wait_until_first_tick_arrived(self) -> None:
+    def _wait_until_first_tick_arrived(self, bot_thread: threading.Thread) -> None:
         """Block the pre-warmed bot thread until the first tick of the round arrives.
         The thread is started at round-started (before any tick), so it must wait here
         before run() can safely read bot state.
@@ -372,7 +375,7 @@ class BaseBotInternals:
         (priority 110) has already captured initial directions via _clear_remaining().
         """
         with self._next_turn_condition:
-            while self.is_running() and self.current_tick_or_null is None:
+            while self.is_running() and self.thread is bot_thread and self.current_tick_or_null is None:
                 self._next_turn_condition.wait()
         # NOTE: Do NOT dispatch events here. Events are dispatched in go() → dispatch_events()
         # which is called from the first blocking bot method (forward, turn_left, etc.) in run().
@@ -382,27 +385,38 @@ class BaseBotInternals:
     def _create_runnable(self, bot: BotABC):
         """Create runnable function for bot thread (matches Java's createRunnable)"""
         def runnable():
-            self.set_running(True)
+            bot_thread = threading.current_thread()
+            with self._thread_control_lock:
+                if self.thread is not bot_thread:
+                    return
+                self.set_running(True)
             try:
-                self._wait_until_first_tick_arrived()
+                self._wait_until_first_tick_arrived(bot_thread)
+                if self.thread is not bot_thread:
+                    return
                 bot.run()
             except ThreadInterruptedException:
                 pass
 
-            self._dispatch_final_turn_events()
+            if self.thread is not bot_thread:
+                return
+            self._dispatch_final_turn_events(bot_thread)
 
             # Skip every turn after the run method has exited
-            while self.is_running():
+            while self.is_running() and self.thread is bot_thread:
                 try:
                     bot.go()
                 except ThreadInterruptedException:
                     break
 
-            self._dispatch_final_turn_events()
+            if self.thread is bot_thread:
+                self._dispatch_final_turn_events(bot_thread)
         return runnable
 
-    def _dispatch_final_turn_events(self) -> None:
+    def _dispatch_final_turn_events(self, bot_thread: threading.Thread) -> None:
         """Dispatch any remaining events from the current tick before the thread exits."""
+        if self.thread is not bot_thread:
+            return
         tick = self.current_tick_or_null
         if tick is not None:
             self.dispatch_events(tick.turn_number)
@@ -410,27 +424,24 @@ class BaseBotInternals:
     def start_thread(self, bot: BotABC) -> None:
         """Start bot thread (matches Java's startThread)"""
         self.enable_event_handling(True)  # reset on WebSocket thread — before new bot thread starts
-        self.thread = threading.Thread(target=self._create_runnable(bot))
-        self.thread.start()
+        new_thread = threading.Thread(target=self._create_runnable(bot))
+        with self._thread_control_lock:
+            self.thread = new_thread
+        new_thread.start()
 
     def stop_thread(self) -> None:
         """Stop bot thread (matches Java's stopThread)"""
-        if not self.is_running():
-            return
-
-        self.set_running(False)
+        with self._thread_control_lock:
+            if not self.is_running() and self.thread is None:
+                return
+            self.set_running(False)
+            self.thread = None  # invalidate ownership before waking the old thread
         self.enable_event_handling(False)  # disable on WebSocket thread — prevents new ticks from queuing after bot stops
 
         # Wake up any threads waiting on the next turn condition so they can see is_running=False
         with self._next_turn_condition:
             self._next_turn_condition.notify_all()
 
-        thread = self.thread
-        self.thread = None
-        if thread is not None and thread is not threading.current_thread():
-            # Wait for the bot thread to finish so that handle_round_ended's
-            # dispatch_events call does not race with _dispatch_final_turn_events.
-            thread.join(timeout=5.0)
 
     def _sanitize_url(self, uri: str) -> None:
         parsed_url = urllib.parse.urlparse(uri)
@@ -620,10 +631,12 @@ class BaseBotInternals:
         # Check if we're being called from the designated bot thread
         # If self.thread is None (test mode with no run() loop) or current thread doesn't match,
         # exit immediately - the intent was already sent in execute() before this call
-        if self.thread is None or threading.current_thread() != self.thread:
+        if self.thread is None:
             # In test mode or when called from wrong thread, just return without waiting
             # This allows tests to call go() from test threads without hanging
             return
+        if threading.current_thread() is not self.thread:
+            raise ThreadInterruptedException()
 
         # Only wait if we're in the correct bot thread and bot is running
         with self._next_turn_condition:
@@ -640,9 +653,8 @@ class BaseBotInternals:
 
     def _stop_rogue_thread(self) -> None:
         """Stop rogue thread (matches Java's stopRogueThread)"""
-        # This method is no longer called from _wait_for_next_turn
-        # Kept for compatibility but effectively disabled
-        pass
+        if self.is_running() and self.thread is not None and threading.current_thread() is not self.thread:
+            raise ThreadInterruptedException()
 
     def set_fire(self, firepower: float) -> bool:
         """Set fire with given firepower. Matches Java's setFire() semantics exactly."""

--- a/bot-api/python/src/robocode_tank_royale/bot_api/internal/websocket_handler.py
+++ b/bot-api/python/src/robocode_tank_royale/bot_api/internal/websocket_handler.py
@@ -98,7 +98,11 @@ class WebSocketHandler:
         # Publish to both event handlers
         disconnected_event = DisconnectedEvent(self.server_url, True, code, reason)
         self.bot_event_handlers.on_disconnected.publish(disconnected_event)
-        self.internal_event_handlers.on_disconnected.publish(disconnected_event)
+        self.internal_event_handlers.on_disconnected.publish(disconnected_event)  # triggers stop_thread()
+
+        # The bot thread no longer owns the round after stop_thread(), so drain its final-tick
+        # events here — otherwise they are lost.
+        self.base_bot_internals.flush_final_turn_events()
         self.closed_event.set()
 
     async def on_error(self, websocket: websockets.ClientConnection, error: Exception):
@@ -202,7 +206,7 @@ class WebSocketHandler:
         # Dispatch any queued events (e.g. WonRoundEvent from the last tick). Bot thread is now
         # stopped so there is no concurrent dispatch race. Must run before ROUND_STARTED clears
         # the event queue.
-        self.event_queue.dispatch_events(schema_evt.turn_number)
+        self.base_bot_internals.dispatch_events(schema_evt.turn_number)
 
         # Transfer any remaining stdout/stderr from event handlers (e.g. on_won_round) before the round ends
         self._transfer_std_out_to_bot_intent()
@@ -249,12 +253,16 @@ class WebSocketHandler:
         game_ended_event.results = ResultsMapper.map(schema_evt.results)
 
         self.bot_event_handlers.on_game_ended.publish(game_ended_event)
-        self.internal_event_handlers.on_game_ended.publish(game_ended_event)
+        self.internal_event_handlers.on_game_ended.publish(game_ended_event)  # triggers stop_thread()
+
+        self.base_bot_internals.flush_final_turn_events()
 
     async def handle_game_aborted(self) -> None:
         """Handle a game aborted event from the server."""
         self.bot_event_handlers.on_game_aborted.publish(None)
-        self.internal_event_handlers.on_game_aborted.publish(None)
+        self.internal_event_handlers.on_game_aborted.publish(None)  # triggers stop_thread()
+
+        self.base_bot_internals.flush_final_turn_events()
 
     async def handle_skipped_turn(self, json_msg: Dict[Any, Any]) -> None:
         """Handle a skipped turn event from the server."""

--- a/bot-api/python/tests/bot_api/test_base_bot_state.py
+++ b/bot-api/python/tests/bot_api/test_base_bot_state.py
@@ -2,6 +2,7 @@ import pytest
 from robocode_tank_royale.bot_api.base_bot import BaseBot
 from robocode_tank_royale.bot_api.bot_info import BotInfo
 from robocode_tank_royale.bot_api.bot_exception import BotException
+from robocode_tank_royale.bot_api.initial_position import InitialPosition
 
 class TestBot(BaseBot):
     def __init__(self):
@@ -53,6 +54,22 @@ def test_TR_API_BOT_007_base_bot_accessor_defaults():
         _ = bot.arena_height
     with pytest.raises(BotException):
         _ = bot.game_type
+
+@pytest.mark.BOT
+def test_TR_API_BOT_007_null_initial_position_components_raise_bot_exception():
+    bot = TestBot()
+    bot._internals.initial_position = InitialPosition(None, None, None)
+
+    with pytest.raises(BotException):
+        _ = bot.x
+    with pytest.raises(BotException):
+        _ = bot.y
+    with pytest.raises(BotException):
+        _ = bot.direction
+    with pytest.raises(BotException):
+        _ = bot.gun_direction
+    with pytest.raises(BotException):
+        _ = bot.radar_direction
 
 @pytest.mark.BOT
 @pytest.mark.LEGACY

--- a/bot-api/python/tests/bot_api/test_round_lifecycle.py
+++ b/bot-api/python/tests/bot_api/test_round_lifecycle.py
@@ -1,0 +1,25 @@
+import threading
+
+import pytest
+
+from robocode_tank_royale.bot_api.bot_info import BotInfo
+from robocode_tank_royale.bot_api.base_bot import BaseBot
+from robocode_tank_royale.bot_api.internal.thread_interrupted_exception import ThreadInterruptedException
+
+
+class TestBot(BaseBot):
+    def __init__(self):
+        super().__init__(BotInfo(name="LifecycleTest", version="1.0", authors=["Test"], game_types={"classic"}))
+
+    def run(self):
+        pass
+
+
+@pytest.mark.BOT
+def test_stale_thread_is_rejected_after_round_owner_changes():
+    internals = TestBot()._internals
+    internals.set_running(True)
+    internals.thread = threading.Thread()
+
+    with pytest.raises(ThreadInterruptedException):
+        internals._stop_rogue_thread()

--- a/bot-api/python/tests/bot_api/test_round_lifecycle.py
+++ b/bot-api/python/tests/bot_api/test_round_lifecycle.py
@@ -1,6 +1,9 @@
 import threading
+import time
 
 import pytest
+
+from robocode_tank_royale.bot_api.events.tick_event import TickEvent
 
 from robocode_tank_royale.bot_api.bot_info import BotInfo
 from robocode_tank_royale.bot_api.base_bot import BaseBot
@@ -31,13 +34,52 @@ def test_stale_thread_is_rejected_after_round_owner_changes():
 
 
 @pytest.mark.BOT
-def test_wait_for_next_turn_returns_when_no_bot_thread_owns_the_round():
-    """Test mode: with no bot thread, go() must not block - the intent was already sent."""
+def test_wait_for_next_turn_unwinds_when_no_bot_thread_owns_the_round():
+    """A BaseBot with no run() loop owns no thread, so go() unwinds after sending the intent.
+
+    This matches Java and .NET, where stopRogueThread() throws whenever the calling thread is
+    not the round owner - including when no thread owns it at all.
+    """
     internals = TestBot()._internals
     internals.set_running(True)
     internals.thread = None
 
-    internals._wait_for_next_turn(1)  # must return rather than raise or hang
+    with pytest.raises(ThreadInterruptedException):
+        internals._wait_for_next_turn(1)
+
+
+@pytest.mark.BOT
+def test_unexpected_error_from_run_still_drains_final_turn_events():
+    """run() blowing up must not cost the bot its final-turn events.
+
+    Mirrored by the Java, .NET and TypeScript lifecycle tests.
+    """
+    dispatched = []
+
+    class ExplodingBot(TestBot):
+        def run(self):
+            raise RuntimeError("boom")
+
+        def go(self):
+            # End the post-run() pre-warm loop on the first go(), the way a stopped bot does.
+            raise ThreadInterruptedException()
+
+        def on_tick(self, event):
+            dispatched.append(event)
+
+    bot = ExplodingBot()
+    internals = bot._internals
+    tick = TickEvent(1, 1, None, [], [])
+    internals.tick_event = tick
+    internals.add_events_from_tick(tick)
+
+    internals.start_thread(bot)
+    deadline = time.monotonic() + 2.0
+    while not dispatched and time.monotonic() < deadline:
+        time.sleep(0.005)
+    internals.stop_thread()
+
+    assert len(dispatched) >= 1
 
 
 @pytest.mark.BOT

--- a/bot-api/python/tests/bot_api/test_round_lifecycle.py
+++ b/bot-api/python/tests/bot_api/test_round_lifecycle.py
@@ -18,8 +18,8 @@ class TestBot(BaseBot):
         pass
 
 
-@pytest.mark.BOT
-def test_stale_thread_is_rejected_after_round_owner_changes():
+@pytest.mark.TCK
+def test_TR_API_TCK_018_stale_thread_is_rejected_after_round_owner_changes():
     """A thread that no longer owns the round is stopped by the blocking bot methods.
 
     _wait_for_next_turn is the production path every blocking bot method funnels through,
@@ -48,8 +48,8 @@ def test_wait_for_next_turn_unwinds_when_no_bot_thread_owns_the_round():
         internals._wait_for_next_turn(1)
 
 
-@pytest.mark.BOT
-def test_unexpected_error_from_run_still_drains_final_turn_events():
+@pytest.mark.TCK
+def test_TR_API_TCK_020_unexpected_error_from_run_still_drains_final_turn_events():
     """run() blowing up must not cost the bot its final-turn events.
 
     Mirrored by the Java, .NET and TypeScript lifecycle tests.
@@ -80,6 +80,31 @@ def test_unexpected_error_from_run_still_drains_final_turn_events():
     internals.stop_thread()
 
     assert len(dispatched) >= 1
+
+
+@pytest.mark.TCK
+def test_TR_API_TCK_019_final_turn_events_flush_after_the_bot_thread_loses_ownership():
+    """Events queued for the current tick still drain once the bot thread stops owning the round.
+
+    This is what the game-ended, game-aborted and disconnected paths rely on.
+    Mirrored by the Java, .NET and TypeScript lifecycle tests.
+    """
+    dispatched = []
+
+    class CountingBot(TestBot):
+        def on_tick(self, event):
+            dispatched.append(event)
+
+    bot = CountingBot()
+    internals = bot._internals
+    tick = TickEvent(1, 1, None, [], [])
+    internals.tick_event = tick
+    internals.add_events_from_tick(tick)
+
+    internals.stop_thread()  # invalidates bot-thread ownership
+    internals.flush_final_turn_events()
+
+    assert len(dispatched) == 1
 
 
 @pytest.mark.BOT

--- a/bot-api/python/tests/bot_api/test_round_lifecycle.py
+++ b/bot-api/python/tests/bot_api/test_round_lifecycle.py
@@ -17,9 +17,33 @@ class TestBot(BaseBot):
 
 @pytest.mark.BOT
 def test_stale_thread_is_rejected_after_round_owner_changes():
+    """A thread that no longer owns the round is stopped by the blocking bot methods.
+
+    _wait_for_next_turn is the production path every blocking bot method funnels through,
+    so the guard is asserted there rather than on _stop_rogue_thread in isolation.
+    """
     internals = TestBot()._internals
     internals.set_running(True)
-    internals.thread = threading.Thread()
+    internals.thread = threading.Thread()  # the round is owned by some other thread
 
     with pytest.raises(ThreadInterruptedException):
-        internals._stop_rogue_thread()
+        internals._wait_for_next_turn(1)
+
+
+@pytest.mark.BOT
+def test_wait_for_next_turn_returns_when_no_bot_thread_owns_the_round():
+    """Test mode: with no bot thread, go() must not block - the intent was already sent."""
+    internals = TestBot()._internals
+    internals.set_running(True)
+    internals.thread = None
+
+    internals._wait_for_next_turn(1)  # must return rather than raise or hang
+
+
+@pytest.mark.BOT
+def test_flush_final_turn_events_is_a_no_op_without_a_tick():
+    """flush_final_turn_events runs on the WebSocket thread after ownership is released."""
+    internals = TestBot()._internals
+    internals.stop_thread()
+
+    internals.flush_final_turn_events()  # no tick yet - must not raise

--- a/bot-api/python/tests/test_shared.py
+++ b/bot-api/python/tests/test_shared.py
@@ -16,6 +16,7 @@ from robocode_tank_royale.bot_api.internal.bot_event_handlers import BotEventHan
 from robocode_tank_royale.bot_api.base_bot import BaseBot as BaseBotClass
 from robocode_tank_royale.bot_api.bot_exception import BotException
 from robocode_tank_royale.bot_api.bot_info import BotInfo
+from robocode_tank_royale.bot_api.initial_position import InitialPosition
 from robocode_tank_royale.bot_api.graphics import Color
 from robocode_tank_royale.bot_api import constants
 from robocode_tank_royale.bot_api.game_type import GameType
@@ -278,6 +279,13 @@ def _run_bot_default(test_case):
         def run(self): pass
 
     bot = BotDefaultStub()
+
+    setup = test_case.get("setup") or {}
+    if "initialPosition" in setup:
+        values = setup["initialPosition"]
+        bot._internals.initial_position = InitialPosition(
+            values.get("x"), values.get("y"), values.get("direction")
+        )
 
     method_map = {
         "getMyId":                  lambda: bot.my_id,

--- a/bot-api/tests/TEST-REGISTRY.md
+++ b/bot-api/tests/TEST-REGISTRY.md
@@ -68,6 +68,10 @@ This applies to all tiers and all categories (VAL, CMD, TCK, BOT, UTL, GFX).
 | TR-API-TCK-015 | BotDeathEvent(victimId!=myId) triggers onBotDeath | 2 | ✅ | ✅ | ✅ | ✅ |
 | TR-API-TCK-016 | BulletHitBotEvent(victimId==myId) triggers onHitByBullet | 2 | ✅ | ✅ | ✅ | ✅ |
 | TR-API-TCK-017 | BulletHitBotEvent(victimId!=myId) triggers onBulletHit | 2 | ✅ | ✅ | ✅ | ✅ |
+| TR-API-TCK-018 | A superseded round's bot loop cannot dispatch or send an intent into the next round | 2 | ✅ | ✅ | ✅ | ✅ |
+| TR-API-TCK-019 | Final-turn events still drain once the bot thread stops owning the round | 2 | ✅ | ✅ | ✅ | ✅ |
+| TR-API-TCK-020 | An unexpected error from run() still drains final-turn events | 2 | ✅ | ✅ | ✅ | ✅ |
+| TR-API-TCK-021 | onWonRound fires once per won round, not once per delivery path | 2 | ❌ | ❌ | ❌ | ✅ |
 
 ## EVT — Events
 
@@ -133,13 +137,13 @@ This applies to all tiers and all categories (VAL, CMD, TCK, BOT, UTL, GFX).
 |----------|-----------|------|----|--------|------------|
 | VAL | 5 | 5 | 5 | 5 | 5 |
 | CMD | 3 | 3 | 3 | 3 | 3 |
-| TCK | 14 | 14 | 14 | 14 | 14 |
+| TCK | 18 | 17 | 17 | 17 | 18 |
 | EVT | 9 | 9 | 9 | 9 | 9 |
 | MDL | 4 | 4 | 4 | 4 | 4 |
 | BOT | 11 | 11 | 11 | 11 | 11 |
 | UTL | 3 | 3 | 3 | 3 | 3 |
 | GFX | 4 | 4 | 4 | 4 | 4 |
-| **Total** | **53** | **53** | **53** | **53** | **53** |
+| **Total** | **57** | **56** | **56** | **56** | **57** |
 
 ---
 

--- a/bot-api/tests/shared/basebot-defaults.json
+++ b/bot-api/tests/shared/basebot-defaults.json
@@ -7,133 +7,331 @@
       "description": "getMyId() throws BotException when not connected to server",
       "type": "botDefault",
       "method": "getMyId",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getVariant-throws",
       "description": "getVariant() throws BotException when not connected to server",
       "type": "botDefault",
       "method": "getVariant",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getVersion-throws",
       "description": "getVersion() throws BotException when not connected to server",
       "type": "botDefault",
       "method": "getVersion",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getEnergy-throws",
       "description": "getEnergy() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getEnergy",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getX-throws",
       "description": "getX() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getX",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getY-throws",
       "description": "getY() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getY",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getDirection-throws",
       "description": "getDirection() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getDirection",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getGunDirection-throws",
       "description": "getGunDirection() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getGunDirection",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getRadarDirection-throws",
       "description": "getRadarDirection() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getRadarDirection",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getSpeed-returns-zero",
       "description": "getSpeed() returns 0 when no tick state is available (safe default)",
       "type": "botDefault",
       "method": "getSpeed",
-      "expected": { "returns": 0 }
+      "expected": {
+        "returns": 0
+      }
     },
     {
       "id": "TR-API-BOT-007-getGunHeat-returns-zero",
       "description": "getGunHeat() returns 0 when no tick state is available (safe default)",
       "type": "botDefault",
       "method": "getGunHeat",
-      "expected": { "returns": 0 }
+      "expected": {
+        "returns": 0
+      }
     },
     {
       "id": "TR-API-BOT-007-getBulletStates-returns-empty",
       "description": "getBulletStates() returns an empty collection when no tick state is available",
       "type": "botDefault",
       "method": "getBulletStates",
-      "expected": { "returnsEmpty": true }
+      "expected": {
+        "returnsEmpty": true
+      }
     },
     {
       "id": "TR-API-BOT-007-getEvents-throws",
       "description": "getEvents() throws BotException when no tick state is available",
       "type": "botDefault",
       "method": "getEvents",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getArenaWidth-throws",
       "description": "getArenaWidth() throws BotException when no game setup is available",
       "type": "botDefault",
       "method": "getArenaWidth",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getArenaHeight-throws",
       "description": "getArenaHeight() throws BotException when no game setup is available",
       "type": "botDefault",
       "method": "getArenaHeight",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-007-getGameType-throws",
       "description": "getGameType() throws BotException when no game setup is available",
       "type": "botDefault",
       "method": "getGameType",
-      "expected": { "throws": "BotException" }
+      "expected": {
+        "throws": "BotException"
+      }
     },
     {
       "id": "TR-API-BOT-008-isAdjustGunForBodyTurn-returns-false",
       "description": "isAdjustGunForBodyTurn() returns false by default",
       "type": "botDefault",
       "method": "isAdjustGunForBodyTurn",
-      "expected": { "returns": false }
+      "expected": {
+        "returns": false
+      }
     },
     {
       "id": "TR-API-BOT-008-isAdjustRadarForBodyTurn-returns-false",
       "description": "isAdjustRadarForBodyTurn() returns false by default",
       "type": "botDefault",
       "method": "isAdjustRadarForBodyTurn",
-      "expected": { "returns": false }
+      "expected": {
+        "returns": false
+      }
     },
     {
       "id": "TR-API-BOT-008-isAdjustRadarForGunTurn-returns-false",
       "description": "isAdjustRadarForGunTurn() returns false by default",
       "type": "botDefault",
       "method": "isAdjustRadarForGunTurn",
-      "expected": { "returns": false }
+      "expected": {
+        "returns": false
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getX-initial-position",
+      "description": "getX() falls back to the initial position when no tick state is available",
+      "type": "botDefault",
+      "method": "getX",
+      "setup": {
+        "initialPosition": {
+          "x": 100.0,
+          "y": 200.0,
+          "direction": 45.0
+        }
+      },
+      "expected": {
+        "returns": 100.0
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getY-initial-position",
+      "description": "getY() falls back to the initial position when no tick state is available",
+      "type": "botDefault",
+      "method": "getY",
+      "setup": {
+        "initialPosition": {
+          "x": 100.0,
+          "y": 200.0,
+          "direction": 45.0
+        }
+      },
+      "expected": {
+        "returns": 200.0
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getDirection-initial-position",
+      "description": "getDirection() falls back to the initial position when no tick state is available",
+      "type": "botDefault",
+      "method": "getDirection",
+      "setup": {
+        "initialPosition": {
+          "x": 100.0,
+          "y": 200.0,
+          "direction": 45.0
+        }
+      },
+      "expected": {
+        "returns": 45.0
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getGunDirection-initial-position",
+      "description": "getGunDirection() falls back to the initial position when no tick state is available",
+      "type": "botDefault",
+      "method": "getGunDirection",
+      "setup": {
+        "initialPosition": {
+          "x": 100.0,
+          "y": 200.0,
+          "direction": 45.0
+        }
+      },
+      "expected": {
+        "returns": 45.0
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getRadarDirection-initial-position",
+      "description": "getRadarDirection() falls back to the initial position when no tick state is available",
+      "type": "botDefault",
+      "method": "getRadarDirection",
+      "setup": {
+        "initialPosition": {
+          "x": 100.0,
+          "y": 200.0,
+          "direction": 45.0
+        }
+      },
+      "expected": {
+        "returns": 45.0
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getX-null-initial-position",
+      "description": "getX() throws BotException when the initial position has no value for it",
+      "type": "botDefault",
+      "method": "getX",
+      "setup": {
+        "initialPosition": {
+          "x": null,
+          "y": null,
+          "direction": null
+        }
+      },
+      "expected": {
+        "throws": "BotException"
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getY-null-initial-position",
+      "description": "getY() throws BotException when the initial position has no value for it",
+      "type": "botDefault",
+      "method": "getY",
+      "setup": {
+        "initialPosition": {
+          "x": null,
+          "y": null,
+          "direction": null
+        }
+      },
+      "expected": {
+        "throws": "BotException"
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getDirection-null-initial-position",
+      "description": "getDirection() throws BotException when the initial position has no value for it",
+      "type": "botDefault",
+      "method": "getDirection",
+      "setup": {
+        "initialPosition": {
+          "x": null,
+          "y": null,
+          "direction": null
+        }
+      },
+      "expected": {
+        "throws": "BotException"
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getGunDirection-null-initial-position",
+      "description": "getGunDirection() throws BotException when the initial position has no value for it",
+      "type": "botDefault",
+      "method": "getGunDirection",
+      "setup": {
+        "initialPosition": {
+          "x": null,
+          "y": null,
+          "direction": null
+        }
+      },
+      "expected": {
+        "throws": "BotException"
+      }
+    },
+    {
+      "id": "TR-API-BOT-007-getRadarDirection-null-initial-position",
+      "description": "getRadarDirection() throws BotException when the initial position has no value for it",
+      "type": "botDefault",
+      "method": "getRadarDirection",
+      "setup": {
+        "initialPosition": {
+          "x": null,
+          "y": null,
+          "direction": null
+        }
+      },
+      "expected": {
+        "throws": "BotException"
+      }
     }
   ]
 }

--- a/bot-api/typescript/src/internal/BaseBotInternals.ts
+++ b/bot-api/typescript/src/internal/BaseBotInternals.ts
@@ -105,9 +105,19 @@ export class BaseBotInternals {
 
   // Thread/worker state
   private running = false;
-  // Monotonic owner token. Each round gets a new token, so a stopped loop
-  // cannot become active again when the next round clears the shared stop flag.
+  // TypeScript has no bot thread, so round ownership is modelled with generation tokens that
+  // mirror the `thread` field the Java/.NET/Python APIs use:
+  //   runGeneration       - monotonic counter; each round's bot loop is issued the next value.
+  //   ownerGeneration     - the token that currently owns the round, or 0 for none
+  //                         (equivalent to thread == null).
+  //   activeRunGeneration - the token of the bot loop frame executing right now
+  //                         (equivalent to Thread.currentThread()).
+  // Bot loops nest: a round-N loop parked in waitForNextTurnWorker() drains worker messages, and
+  // a roundStarted message starts the round-N+1 loop on top of it. activeRunGeneration is saved
+  // and restored around each frame so a resumed round-N frame is still recognised as stale.
   private runGeneration = 0;
+  private ownerGeneration = 0;
+  private activeRunGeneration = 0;
   private eventHandlingDisabledTurn = 0;
   private lastExecuteTurnNumber = -1;
   private movementResetPending = false;
@@ -352,7 +362,11 @@ export class BaseBotInternals {
     } else {
       const e = new DisconnectedEvent(this.serverUrl, remote, code, reason);
       this.botEventHandlers.onDisconnected.publish(e);
-      this.internalEventHandlers.onDisconnected.publish(e);
+      this.internalEventHandlers.onDisconnected.publish(e); // triggers stopThread()
+      this.stopThread();
+      // The bot loop no longer owns the round, so drain its final-tick events here.
+      this.flushFinalTurnEvents();
+      return;
     }
     this.stopThread();
   }
@@ -392,6 +406,7 @@ export class BaseBotInternals {
       this.forwardToWorker("gameAborted");
     } else {
       this.internalEventHandlers.fireGameAborted();
+      this.flushFinalTurnEvents();
     }
   }
 
@@ -453,7 +468,8 @@ export class BaseBotInternals {
         {
           const e = new DisconnectedEvent(msg.data.serverUrl, msg.data.remote, msg.data.code, msg.data.reason);
           this.botEventHandlers.onDisconnected.publish(e);
-          this.internalEventHandlers.onDisconnected.publish(e);
+          this.internalEventHandlers.onDisconnected.publish(e); // triggers stopThread()
+          this.flushFinalTurnEvents();
         }
         break;
       case "connectionError":
@@ -471,7 +487,8 @@ export class BaseBotInternals {
         break;
       case "gameAborted":
         this.keepRunningGame = false;
-        this.internalEventHandlers.fireGameAborted();
+        this.internalEventHandlers.fireGameAborted(); // triggers stopThread()
+        this.flushFinalTurnEvents();
         break;
       case "roundStarted":
         this.processRoundStarted(msg.data);
@@ -508,7 +525,9 @@ export class BaseBotInternals {
     const results = ResultsMapper.map(msg.results);
     const e = new GameEndedEvent(msg.numberOfRounds, results);
     this.botEventHandlers.onGameEnded.publish(e);
-    this.internalEventHandlers.onGameEnded.publish(e);
+    this.internalEventHandlers.onGameEnded.publish(e); // triggers stopThread()
+
+    this.flushFinalTurnEvents();
   }
 
   private processRoundStarted(msg: import("../protocol/schema.js").RoundStartedEvent): void {
@@ -608,9 +627,15 @@ export class BaseBotInternals {
         this.movementResetPending = false;
       }
     }
-    const generation = this.runGeneration;
+    // Use the generation of the frame we are actually running in, not the newest one. A stale
+    // round's run() that swallowed BotStoppedException and called another blocking method must
+    // not be able to re-arm itself against the new round's token and send an intent into it.
+    const generation = this.activeRunGeneration !== 0 ? this.activeRunGeneration : this.ownerGeneration;
+    if (generation !== this.ownerGeneration) {
+      throw new BotStoppedException();
+    }
     this.waitForNextTurnWorker(capturedTurnNumber, generation);
-    if (generation !== this.runGeneration) {
+    if (generation !== this.ownerGeneration) {
       throw new BotStoppedException();
     }
     // Dispatch events for the new turn *after* waiting, so that run() always reads state
@@ -657,7 +682,7 @@ export class BaseBotInternals {
 
   private waitForNextTurnWorker(currentTurnNumber: number, generation: number): void {
     this.stopRogueThread();
-    while (this.running && generation === this.runGeneration && (this.tickEvent?.turnNumber ?? 0) === currentTurnNumber) {
+    while (this.running && generation === this.ownerGeneration && (this.tickEvent?.turnNumber ?? 0) === currentTurnNumber) {
       this.stopRogueThread();
       if (this.sharedView == null) break;
       const curVal = Atomics.load(this.sharedView, SAB_SLOT_TURN);
@@ -692,33 +717,40 @@ export class BaseBotInternals {
       this.sharedView = new Int32Array(this.sharedBuffer);
     }
     const generation = ++this.runGeneration;
+    this.ownerGeneration = generation; // publish ownership before the loop starts
     Atomics.store(this.sharedView, SAB_SLOT_STOP, 0);
     this.runBotLoop(bot, generation);
   }
 
   private runBotLoop(bot: IBot, generation: number): void {
-    if (generation !== this.runGeneration) return;
-    this.setRunning(true);
+    if (generation !== this.ownerGeneration) return;
+    const previousActive = this.activeRunGeneration;
+    this.activeRunGeneration = generation;
     try {
-      this.waitUntilFirstTickArrived(generation);
-      if (generation !== this.runGeneration) return;
-      bot.run();
-    } catch (e) {
-      if (!(e instanceof BotStoppedException)) {
-        // ignore unexpected errors from bot.run()
-      }
-    }
-    if (generation !== this.runGeneration) return;
-    this.dispatchFinalTurnEvents(generation);
-    while (this.running && generation === this.runGeneration) {
+      this.setRunning(true);
       try {
-        bot.go();
+        this.waitUntilFirstTickArrived(generation);
+        if (generation !== this.ownerGeneration) return;
+        bot.run();
       } catch (e) {
-        if (e instanceof BotStoppedException) break;
+        if (!(e instanceof BotStoppedException)) {
+          // ignore unexpected errors from bot.run()
+        }
       }
-    }
-    if (generation === this.runGeneration) {
+      if (generation !== this.ownerGeneration) return;
       this.dispatchFinalTurnEvents(generation);
+      while (this.running && generation === this.ownerGeneration) {
+        try {
+          bot.go();
+        } catch (e) {
+          if (e instanceof BotStoppedException) break;
+        }
+      }
+      if (generation === this.ownerGeneration) {
+        this.dispatchFinalTurnEvents(generation);
+      }
+    } finally {
+      this.activeRunGeneration = previousActive;
     }
   }
 
@@ -730,7 +762,7 @@ export class BaseBotInternals {
   // Only applicable in worker mode — in legacy (non-worker) mode, returns immediately.
   private waitUntilFirstTickArrived(generation: number): void {
     if (!this.workerMode || this.sharedView == null) return;
-    while (this.tickEvent == null && this.running && generation === this.runGeneration) {
+    while (this.tickEvent == null && this.running && generation === this.ownerGeneration) {
       const curVal = Atomics.load(this.sharedView, SAB_SLOT_TURN);
       Atomics.wait(this.sharedView, SAB_SLOT_TURN, curVal, 500);
       this.drainWorkerMessages();
@@ -743,8 +775,8 @@ export class BaseBotInternals {
   }
 
   stopThread(): void {
-    if (!this.running) return;
-    this.runGeneration++;
+    if (!this.running && this.ownerGeneration === 0) return;
+    this.ownerGeneration = 0; // invalidate ownership before waking the old loop
     this.setRunning(false);
     this.enableEventHandling(false);
     if (this.sharedView != null) {
@@ -784,11 +816,34 @@ export class BaseBotInternals {
   }
 
   dispatchEvents(turnNumber: number): void {
+    // Worker mode is the TypeScript analogue of a dedicated bot thread: only the loop frame that
+    // still owns the round may dispatch (mirrors the thread-ownership guard in Java/.NET/Python).
+    // Once ownership is released (ownerGeneration === 0) the WebSocket side drains freely, which
+    // is what processRoundEnded() and flushFinalTurnEvents() rely on.
+    if (
+      this.workerMode &&
+      this.running &&
+      this.ownerGeneration !== 0 &&
+      this.activeRunGeneration !== 0 &&
+      this.activeRunGeneration !== this.ownerGeneration
+    ) {
+      throw new BotStoppedException();
+    }
     this.eventQueue.dispatchEvents(turnNumber, this.botEventHandlers);
   }
 
-  dispatchFinalTurnEvents(generation = this.runGeneration): void {
-    if (generation !== this.runGeneration) return;
+  private dispatchFinalTurnEvents(generation: number): void {
+    if (generation !== this.ownerGeneration) return;
+    this.flushFinalTurnEvents();
+  }
+
+  /**
+   * Drains any events still queued for the current tick. Called from the WebSocket side after
+   * stopThread() has invalidated round ownership, so the bot loop can no longer drain them
+   * itself. Without this, final-tick events would be lost on game-ended, game-aborted and
+   * disconnected.
+   */
+  flushFinalTurnEvents(): void {
     if (this.tickEvent != null) {
       this.dispatchEvents(this.tickEvent.turnNumber);
     }

--- a/bot-api/typescript/src/internal/BaseBotInternals.ts
+++ b/bot-api/typescript/src/internal/BaseBotInternals.ts
@@ -105,6 +105,9 @@ export class BaseBotInternals {
 
   // Thread/worker state
   private running = false;
+  // Monotonic owner token. Each round gets a new token, so a stopped loop
+  // cannot become active again when the next round clears the shared stop flag.
+  private runGeneration = 0;
   private eventHandlingDisabledTurn = 0;
   private lastExecuteTurnNumber = -1;
   private movementResetPending = false;
@@ -605,7 +608,11 @@ export class BaseBotInternals {
         this.movementResetPending = false;
       }
     }
-    this.waitForNextTurnWorker(capturedTurnNumber);
+    const generation = this.runGeneration;
+    this.waitForNextTurnWorker(capturedTurnNumber, generation);
+    if (generation !== this.runGeneration) {
+      throw new BotStoppedException();
+    }
     // Dispatch events for the new turn *after* waiting, so that run() always reads state
     // that matches the events that just fired — matching Classic Robocode semantics.
     if (this.tickEvent != null) {
@@ -648,9 +655,9 @@ export class BaseBotInternals {
     this.intent.debugGraphics = null;
   }
 
-  private waitForNextTurnWorker(currentTurnNumber: number): void {
+  private waitForNextTurnWorker(currentTurnNumber: number, generation: number): void {
     this.stopRogueThread();
-    while (this.running && (this.tickEvent?.turnNumber ?? 0) === currentTurnNumber) {
+    while (this.running && generation === this.runGeneration && (this.tickEvent?.turnNumber ?? 0) === currentTurnNumber) {
       this.stopRogueThread();
       if (this.sharedView == null) break;
       const curVal = Atomics.load(this.sharedView, SAB_SLOT_TURN);
@@ -684,29 +691,35 @@ export class BaseBotInternals {
       this.sharedBuffer = new SharedArrayBuffer(SAB_LENGTH * 4);
       this.sharedView = new Int32Array(this.sharedBuffer);
     }
+    const generation = ++this.runGeneration;
     Atomics.store(this.sharedView, SAB_SLOT_STOP, 0);
-    this.runBotLoop(bot);
+    this.runBotLoop(bot, generation);
   }
 
-  private runBotLoop(bot: IBot): void {
+  private runBotLoop(bot: IBot, generation: number): void {
+    if (generation !== this.runGeneration) return;
     this.setRunning(true);
     try {
-      this.waitUntilFirstTickArrived();
+      this.waitUntilFirstTickArrived(generation);
+      if (generation !== this.runGeneration) return;
       bot.run();
     } catch (e) {
       if (!(e instanceof BotStoppedException)) {
         // ignore unexpected errors from bot.run()
       }
     }
-    this.dispatchFinalTurnEvents();
-    while (this.running) {
+    if (generation !== this.runGeneration) return;
+    this.dispatchFinalTurnEvents(generation);
+    while (this.running && generation === this.runGeneration) {
       try {
         bot.go();
       } catch (e) {
         if (e instanceof BotStoppedException) break;
       }
     }
-    this.dispatchFinalTurnEvents();
+    if (generation === this.runGeneration) {
+      this.dispatchFinalTurnEvents(generation);
+    }
   }
 
   isWorkerMode(): boolean { return this.workerMode; }
@@ -715,9 +728,9 @@ export class BaseBotInternals {
   // The thread is started at round-started (before any tick), so it must wait here
   // before run() can safely read bot state (radar direction, etc.).
   // Only applicable in worker mode — in legacy (non-worker) mode, returns immediately.
-  private waitUntilFirstTickArrived(): void {
+  private waitUntilFirstTickArrived(generation: number): void {
     if (!this.workerMode || this.sharedView == null) return;
-    while (this.tickEvent == null && this.running) {
+    while (this.tickEvent == null && this.running && generation === this.runGeneration) {
       const curVal = Atomics.load(this.sharedView, SAB_SLOT_TURN);
       Atomics.wait(this.sharedView, SAB_SLOT_TURN, curVal, 500);
       this.drainWorkerMessages();
@@ -731,6 +744,7 @@ export class BaseBotInternals {
 
   stopThread(): void {
     if (!this.running) return;
+    this.runGeneration++;
     this.setRunning(false);
     this.enableEventHandling(false);
     if (this.sharedView != null) {
@@ -773,7 +787,8 @@ export class BaseBotInternals {
     this.eventQueue.dispatchEvents(turnNumber, this.botEventHandlers);
   }
 
-  dispatchFinalTurnEvents(): void {
+  dispatchFinalTurnEvents(generation = this.runGeneration): void {
+    if (generation !== this.runGeneration) return;
     if (this.tickEvent != null) {
       this.dispatchEvents(this.tickEvent.turnNumber);
     }

--- a/bot-api/typescript/src/internal/BaseBotInternals.ts
+++ b/bot-api/typescript/src/internal/BaseBotInternals.ts
@@ -13,7 +13,6 @@ import { BotEventHandlers } from "../events/BotEventHandlers.js";
 import { TickEvent } from "../events/TickEvent.js";
 import { RoundStartedEvent as RoundStartedEventClass } from "../events/RoundStartedEvent.js";
 import { BulletFiredEvent } from "../events/BulletFiredEvent.js";
-import { WonRoundEvent } from "../events/WonRoundEvent.js";
 import { SkippedTurnEvent } from "../events/SkippedTurnEvent.js";
 import { ConnectedEvent } from "../events/ConnectedEvent.js";
 import { DisconnectedEvent } from "../events/DisconnectedEvent.js";
@@ -82,6 +81,7 @@ export class BaseBotInternals {
   private variant = "";
   private version = "";
   private gameSetup: GameSetup | null = null;
+  private initialPosition: InitialPosition | null = null;
   private tickEvent: TickEvent | null = null;
   private tickStartTime = 0;
   private teammateIds: Set<number> = new Set();
@@ -516,8 +516,8 @@ export class BaseBotInternals {
     this.myId = msg.myId;
     this.gameSetup = GameSetupMapper.map(msg.gameSetup);
     this.teammateIds = new Set(msg.teammateIds ?? []);
-    const initialPosition = new InitialPosition(msg.startX ?? null, msg.startY ?? null, msg.startDirection ?? null);
-    const e = new GameStartedEvent(msg.myId, initialPosition, this.gameSetup);
+    this.initialPosition = new InitialPosition(msg.startX ?? null, msg.startY ?? null, msg.startDirection ?? null);
+    const e = new GameStartedEvent(msg.myId, this.initialPosition, this.gameSetup);
     this.botEventHandlers.onGameStarted.publish(e);
   }
 
@@ -547,11 +547,6 @@ export class BaseBotInternals {
     // Flush any queued events from the last tick (e.g. WonRoundEvent) before the next
     // RoundStartedEvent clears the event queue.
     this.dispatchEvents(msg.turnNumber);
-
-    // If the bot won this round (rank == 1), ensure onWonRound is triggered.
-    if (results != null && results.rank === 1) {
-      this.botEventHandlers.onWonRound.publish(new WonRoundEvent(msg.turnNumber));
-    }
   }
 
   private processTick(msg: import("../protocol/schema.js").TickEventForBot): void {
@@ -733,8 +728,10 @@ export class BaseBotInternals {
         if (generation !== this.ownerGeneration) return;
         bot.run();
       } catch (e) {
-        if (!(e instanceof BotStoppedException)) {
-          // ignore unexpected errors from bot.run()
+        // Report unexpected errors from run(), but stay silent once this frame has been
+        // superseded - the failure is then just fallout from losing the round.
+        if (!(e instanceof BotStoppedException) && generation === this.ownerGeneration) {
+          console.error(e);
         }
       }
       if (generation !== this.ownerGeneration) return;
@@ -928,24 +925,29 @@ export class BaseBotInternals {
   }
   isDisabled(): boolean { return this.tickEvent != null && this.getEnergy() === 0; }
   getX(): number {
-    if (this.tickEvent == null) throw new BotException(TICK_NOT_AVAILABLE_MSG);
-    return this.tickEvent.botState.x;
+    if (this.tickEvent != null) return this.tickEvent.botState.x;
+    if (this.initialPosition?.x != null) return this.initialPosition.x;
+    throw new BotException(TICK_NOT_AVAILABLE_MSG);
   }
   getY(): number {
-    if (this.tickEvent == null) throw new BotException(TICK_NOT_AVAILABLE_MSG);
-    return this.tickEvent.botState.y;
+    if (this.tickEvent != null) return this.tickEvent.botState.y;
+    if (this.initialPosition?.y != null) return this.initialPosition.y;
+    throw new BotException(TICK_NOT_AVAILABLE_MSG);
   }
   getDirection(): number {
-    if (this.tickEvent == null) throw new BotException(TICK_NOT_AVAILABLE_MSG);
-    return this.tickEvent.botState.direction;
+    if (this.tickEvent != null) return this.tickEvent.botState.direction;
+    if (this.initialPosition?.direction != null) return this.initialPosition.direction;
+    throw new BotException(TICK_NOT_AVAILABLE_MSG);
   }
   getGunDirection(): number {
-    if (this.tickEvent == null) throw new BotException(TICK_NOT_AVAILABLE_MSG);
-    return this.tickEvent.botState.gunDirection;
+    if (this.tickEvent != null) return this.tickEvent.botState.gunDirection;
+    if (this.initialPosition?.direction != null) return this.initialPosition.direction;
+    throw new BotException(TICK_NOT_AVAILABLE_MSG);
   }
   getRadarDirection(): number {
-    if (this.tickEvent == null) throw new BotException(TICK_NOT_AVAILABLE_MSG);
-    return this.tickEvent.botState.radarDirection;
+    if (this.tickEvent != null) return this.tickEvent.botState.radarDirection;
+    if (this.initialPosition?.direction != null) return this.initialPosition.direction;
+    throw new BotException(TICK_NOT_AVAILABLE_MSG);
   }
   getSpeed(): number {
     return this.tickEvent?.botState.speed ?? 0;

--- a/bot-api/typescript/test/BotLifecycle.test.ts
+++ b/bot-api/typescript/test/BotLifecycle.test.ts
@@ -14,6 +14,7 @@ import { TickEvent } from "../src/events/TickEvent.js";
 import { BotState } from "../src/BotState.js";
 import { Condition } from "../src/events/Condition.js";
 import { SkippedTurnEvent } from "../src/events/SkippedTurnEvent.js";
+import { WonRoundEvent } from "../src/events/WonRoundEvent.js";
 import { GameSetup } from "../src/GameSetup.js";
 import { BotResults } from "../src/BotResults.js";
 import { MessageType } from "../src/protocol/MessageType.js";
@@ -295,6 +296,32 @@ describe("Task 4: BaseBotInternals", () => {
     internals.flushFinalTurnEvents();
 
     expect(spy).toHaveBeenCalledWith(7);
+  });
+
+  it("4.11d an unexpected error from run() still drains final-turn events", () => {
+    // run() blowing up must not cost the bot its final-turn events.
+    // Mirrored by the Java, .NET and Python lifecycle tests.
+    const stub = {} as import("../src/IBaseBot.js").IBaseBot;
+    const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
+    const privateInternals = internals as unknown as {
+      workerMode: boolean;
+      tickEvent: TickEvent | null;
+    };
+    privateInternals.workerMode = true;
+    privateInternals.tickEvent = new TickEvent(1, 1, null as unknown as BotState, [], []);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const spy = vi.spyOn(internals, "dispatchFinalTurnEvents" as never);
+    const explodingBot = {
+      run: () => { throw new Error("boom"); },
+      go: () => { internals.setRunning(false); },
+    } as unknown as import("../src/IBot.js").IBot;
+
+    internals.startThread(explodingBot);
+
+    expect(spy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled(); // the failure is reported, not swallowed
+    errorSpy.mockRestore();
   });
 
   it("4.12 state accessors return defaults before game starts", () => {
@@ -670,6 +697,38 @@ describe("Task 8: Integration tests", () => {
     internals.setResume();
     expect(internals.getTurnRate()).toBe(5);
     expect(internals.getTargetSpeed()).toBe(4);
+  });
+
+  it("8.11b onWonRound fires once per won round, not once per delivery path", () => {
+    // The server delivers WonRoundEvent inside the final tick. Synthesising a second one at
+    // round-ended (from results.rank === 1) made TypeScript fire onWonRound twice, unlike the
+    // Java, .NET and Python Bot APIs. makeResults() has rank 1, so this covers that case.
+    const { internals, simulateGameStarted, simulateRoundStarted, simulateTick, simulateRoundEnded } =
+      buildInternals();
+    let wonRoundCount = 0;
+    internals.botEventHandlers.onWonRound.subscribe(() => { wonRoundCount++; }, 100);
+
+    simulateGameStarted();
+    simulateRoundStarted();
+    simulateTick(1);
+    internals.addEvent(new WonRoundEvent(1));
+    simulateRoundEnded();
+
+    expect(wonRoundCount).toBe(1);
+  });
+
+  it("8.11c onWonRound does not fire when the server never sent a WonRoundEvent", () => {
+    const { internals, simulateGameStarted, simulateRoundStarted, simulateTick, simulateRoundEnded } =
+      buildInternals();
+    let wonRoundCount = 0;
+    internals.botEventHandlers.onWonRound.subscribe(() => { wonRoundCount++; }, 100);
+
+    simulateGameStarted();
+    simulateRoundStarted();
+    simulateTick(1);
+    simulateRoundEnded(); // results.rank === 1, but no WonRoundEvent was delivered
+
+    expect(wonRoundCount).toBe(0);
   });
 
   it("8.11 isRunning returns false after round ended", () => {

--- a/bot-api/typescript/test/BotLifecycle.test.ts
+++ b/bot-api/typescript/test/BotLifecycle.test.ts
@@ -229,6 +229,25 @@ describe("Task 4: BaseBotInternals", () => {
     expect(internals.isEventHandlingDisabled()).toBe(false);
   });
 
+  it("4.11 stopping a worker invalidates its round generation", () => {
+    const stub = {} as import("../src/IBaseBot.js").IBaseBot;
+    const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
+    const privateInternals = internals as unknown as {
+      runGeneration: number;
+      sharedBuffer: SharedArrayBuffer;
+      sharedView: Int32Array;
+    };
+    privateInternals.sharedBuffer = new SharedArrayBuffer(8);
+    privateInternals.sharedView = new Int32Array(privateInternals.sharedBuffer);
+    internals.setRunning(true);
+    const generation = privateInternals.runGeneration;
+
+    internals.stopThread();
+
+    expect(privateInternals.runGeneration).toBe(generation + 1);
+    expect(internals.isRunning()).toBe(false);
+  });
+
   it("4.12 state accessors return defaults before game starts", () => {
     const stub = {} as import("../src/IBaseBot.js").IBaseBot;
     const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);

--- a/bot-api/typescript/test/BotLifecycle.test.ts
+++ b/bot-api/typescript/test/BotLifecycle.test.ts
@@ -249,7 +249,7 @@ describe("Task 4: BaseBotInternals", () => {
     expect(internals.isRunning()).toBe(false);
   });
 
-  it("4.11b a superseded loop frame cannot execute into the next round", () => {
+  it("TR-API-TCK-018: a superseded loop frame cannot execute into the next round", () => {
     const stub = {} as import("../src/IBaseBot.js").IBaseBot;
     const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
     const privateInternals = internals as unknown as {
@@ -277,7 +277,7 @@ describe("Task 4: BaseBotInternals", () => {
     expect(() => internals.dispatchEvents(1)).not.toThrow();
   });
 
-  it("4.11c releasing ownership lets the WebSocket side drain the final tick", () => {
+  it("TR-API-TCK-019: releasing ownership lets the WebSocket side drain the final tick", () => {
     const stub = {} as import("../src/IBaseBot.js").IBaseBot;
     const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
     const privateInternals = internals as unknown as {
@@ -298,7 +298,7 @@ describe("Task 4: BaseBotInternals", () => {
     expect(spy).toHaveBeenCalledWith(7);
   });
 
-  it("4.11d an unexpected error from run() still drains final-turn events", () => {
+  it("TR-API-TCK-020: an unexpected error from run() still drains final-turn events", () => {
     // run() blowing up must not cost the bot its final-turn events.
     // Mirrored by the Java, .NET and Python lifecycle tests.
     const stub = {} as import("../src/IBaseBot.js").IBaseBot;
@@ -699,7 +699,7 @@ describe("Task 8: Integration tests", () => {
     expect(internals.getTargetSpeed()).toBe(4);
   });
 
-  it("8.11b onWonRound fires once per won round, not once per delivery path", () => {
+  it("TR-API-TCK-021: onWonRound fires once per won round, not once per delivery path", () => {
     // The server delivers WonRoundEvent inside the final tick. Synthesising a second one at
     // round-ended (from results.rank === 1) made TypeScript fire onWonRound twice, unlike the
     // Java, .NET and Python Bot APIs. makeResults() has rank 1, so this covers that case.
@@ -717,7 +717,7 @@ describe("Task 8: Integration tests", () => {
     expect(wonRoundCount).toBe(1);
   });
 
-  it("8.11c onWonRound does not fire when the server never sent a WonRoundEvent", () => {
+  it("TR-API-TCK-021: onWonRound does not fire when the server never sent a WonRoundEvent", () => {
     const { internals, simulateGameStarted, simulateRoundStarted, simulateTick, simulateRoundEnded } =
       buildInternals();
     let wonRoundCount = 0;

--- a/bot-api/typescript/test/BotLifecycle.test.ts
+++ b/bot-api/typescript/test/BotLifecycle.test.ts
@@ -233,19 +233,68 @@ describe("Task 4: BaseBotInternals", () => {
     const stub = {} as import("../src/IBaseBot.js").IBaseBot;
     const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
     const privateInternals = internals as unknown as {
-      runGeneration: number;
+      ownerGeneration: number;
       sharedBuffer: SharedArrayBuffer;
       sharedView: Int32Array;
     };
     privateInternals.sharedBuffer = new SharedArrayBuffer(8);
     privateInternals.sharedView = new Int32Array(privateInternals.sharedBuffer);
     internals.setRunning(true);
-    const generation = privateInternals.runGeneration;
+    privateInternals.ownerGeneration = 7;
 
     internals.stopThread();
 
-    expect(privateInternals.runGeneration).toBe(generation + 1);
+    expect(privateInternals.ownerGeneration).toBe(0);
     expect(internals.isRunning()).toBe(false);
+  });
+
+  it("4.11b a superseded loop frame cannot execute into the next round", () => {
+    const stub = {} as import("../src/IBaseBot.js").IBaseBot;
+    const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
+    const privateInternals = internals as unknown as {
+      workerMode: boolean;
+      ownerGeneration: number;
+      activeRunGeneration: number;
+      sharedBuffer: SharedArrayBuffer;
+      sharedView: Int32Array;
+    };
+    privateInternals.sharedBuffer = new SharedArrayBuffer(8);
+    privateInternals.sharedView = new Int32Array(privateInternals.sharedBuffer);
+    privateInternals.workerMode = true;
+    internals.setRunning(true);
+
+    // Round 2 owns the bot, but we are still on round 1's stack — the shape a run() that
+    // swallowed BotStoppedException and called another blocking method ends up in.
+    privateInternals.ownerGeneration = 2;
+    privateInternals.activeRunGeneration = 1;
+
+    expect(() => internals.execute(1)).toThrow(BotStoppedException);
+    expect(() => internals.dispatchEvents(1)).toThrow(BotStoppedException);
+
+    // The owning frame is unaffected.
+    privateInternals.activeRunGeneration = 2;
+    expect(() => internals.dispatchEvents(1)).not.toThrow();
+  });
+
+  it("4.11c releasing ownership lets the WebSocket side drain the final tick", () => {
+    const stub = {} as import("../src/IBaseBot.js").IBaseBot;
+    const internals = new BaseBotInternals(stub, makeBotInfo(), null, undefined);
+    const privateInternals = internals as unknown as {
+      workerMode: boolean;
+      ownerGeneration: number;
+      activeRunGeneration: number;
+      tickEvent: TickEvent | null;
+    };
+    privateInternals.workerMode = true;
+    internals.setRunning(true);
+    privateInternals.tickEvent = new TickEvent(7, 1, null as unknown as BotState, [], []);
+    privateInternals.ownerGeneration = 0; // stopThread() has run
+    privateInternals.activeRunGeneration = 1;
+
+    const spy = vi.spyOn(internals, "dispatchEvents");
+    internals.flushFinalTurnEvents();
+
+    expect(spy).toHaveBeenCalledWith(7);
   });
 
   it("4.12 state accessors return defaults before game starts", () => {

--- a/bot-api/typescript/test/SharedTestRunner.test.ts
+++ b/bot-api/typescript/test/SharedTestRunner.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { BaseBotInternals } from '../src/internal/BaseBotInternals.js';
 import { IntentValidator } from '../src/internal/intentValidator.js';
 import { BotInfo } from '../src/BotInfo.js';
+import { InitialPosition } from '../src/InitialPosition.js';
 import { Color } from '../src/graphics/Color.js';
 import { Constants } from '../src/Constants.js';
 import { TickEvent } from '../src/events/TickEvent.js';
@@ -235,6 +236,13 @@ function executeBotDefault(testCase: TestCase): void {
     run() {}
   }
   const bot = new BotDefaultStub();
+
+  const setup = testCase.setup;
+  if (setup?.initialPosition) {
+    const values = setup.initialPosition as { x: number | null; y: number | null; direction: number | null };
+    (bot as any)._internals.initialPosition =
+      new InitialPosition(values.x ?? null, values.y ?? null, values.direction ?? null);
+  }
 
   const methodMap: Record<string, () => any> = {
     'getMyId':                  () => bot.getMyId(),

--- a/docs/decisions/PDR-013-typescript-console-output-plan.md
+++ b/docs/decisions/PDR-013-typescript-console-output-plan.md
@@ -1,0 +1,23 @@
+---
+id: PDR-013
+type: decision
+status: inferred
+links: [P-005]
+title: TypeScript console-output parity is a tracked plan, not a defect fix
+author: agent
+accepted-by: []
+---
+
+# PDR-013 — TypeScript console-output parity is a tracked plan, not a defect fix
+
+## Context
+
+The TypeScript Bot API never populates `BotIntent.stdOut` or `stdErr`, so a TypeScript bot's console output never reaches the GUI. The other three Bot APIs have carried this since before the corpus. It reads as a small omission, but TypeScript runs bot code inside a Worker and assembles the intent there, so the capture point and the Worker crossing have to be decided before anything is written, and the browser path has no `process.stdout` to record.
+
+## Decision
+
+The gap is represented by plan P-005 with milestones M-016 through M-018, rather than being folded into a parity change as a defect fix. The capture boundary earns its own IDR under M-016 before implementation begins.
+
+## Consequences
+
+C-003's parity residual continues to name console output as an open divergence until M-018 closes it. Parity work that touches the TypeScript Bot API may cite P-005 rather than restating the gap.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -72,4 +72,5 @@ Writing guidelines: be specific (technical detail, not concepts); show your work
 - [PDR-011 — Empty extracted specifications create no capability](PDR-011-empty-extraction-directory.md) · `inferred` — The `browser-sample-bots` OpenSpec directory contained no requirements to preserve.
 - [PDR-012 — Typed decision records replace the legacy decision log](PDR-012-typed-decision-record-carrier.md) · `inferred` — The legacy decision log mixed architecture, process, implementation, and routine history in one carrier that obscured the enduring subject of each choice.
 - [ADR-047 — Rumble catalog publishes immutable team membership](ADR-047-rumble-catalog-publishes-team-membership.md) · `verified` — The V1 engine pin counts the four bot processes in a TwinDuel battle, while Battle Runner starts two team entries and result ingestion receives two team results.
+- [PDR-013 — TypeScript console-output parity is a tracked plan, not a defect fix](PDR-013-typescript-console-output-plan.md) · `inferred` — The TypeScript Bot API never populates `BotIntent.stdOut` or `stdErr`, so a TypeScript bot's console output never reaches the GUI.
 <!-- clue:index:end -->

--- a/docs/plans/P-005-typescript-bot-console-output.md
+++ b/docs/plans/P-005-typescript-bot-console-output.md
@@ -1,0 +1,31 @@
+---
+id: P-005
+type: plan
+status: draft
+links: [G-001]
+title: TypeScript bot console output reaches the GUI
+provenance: inferred
+reversal-cost: low
+---
+
+# P-005 — TypeScript bot console output reaches the GUI
+
+TypeScript bot authors see none of their console output in the GUI, unlike authors on the other three Bot APIs.
+
+A bot's console output reaches the GUI only through `BotIntent.stdOut` and `BotIntent.stdErr`: the booter discards a bot process's stdout pipe outright (`BotBooter.kt`), so the pipe is not a second route. The Java, .NET and Python Bot APIs each install a recording stream over the process's standard streams and drain it into the intent on every send and again after a round ends. The TypeScript Bot API never populates either field.
+
+The protocol side is already in place: `stdOut` and `stdErr` exist on `BotIntent` in the TypeScript schema. What is missing is the capture and the plumbing.
+
+TypeScript is the only Bot API where this is not a mechanical port. Its bot code runs inside a Worker by default, and the intent is assembled there and handed to the main thread by `postMessage`. Capture must therefore happen on the Worker side and travel with the intent, and the same code has to behave sensibly in the non-worker path and in a browser, where `process.stdout` does not exist and only `console` can be intercepted. That boundary question is what makes this a campaign rather than a single change.
+
+Serves G-001: cross-platform play only counts when a bot author switching language does not lose a facility the other languages provide. Closes the standing-output portion of the C-003 parity residual.
+
+| ID | Milestone | Exit criterion | Status | Evidence |
+|---|---|---|---|---|
+| M-016 | Capture boundary decided | An accepted IDR states where TypeScript captures console output, how it crosses the Worker boundary with the intent, and what the non-worker and browser paths do | todo | |
+| M-017 | Console output populates the intent | `BotIntent.stdOut` and `stdErr` carry the bot's output on every intent send and after a round ends, in both worker and non-worker modes, matching where the Java Bot API drains its recording streams | todo | |
+| M-018 | Parity evidenced and residual closed | Tests mirror the Java, .NET and Python coverage for standard-stream capture, and C-003's residual no longer names console output as an open divergence | todo | |
+
+M-017 depends on M-016. M-018 depends on M-017.
+
+This plan does not cover the GUI's rendering of bot output, which already works for the other three Bot APIs and is unchanged by it.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,4 +10,5 @@ Every change proposal names the plan item it serves, or explicitly declares itse
 - [P-001 — Cliewen adoption](P-001-cliewen-adoption.md) · `active`
 - [P-002 — TypeScript Bot API reaches npm](P-002-typescript-bot-api-npm.md) · `completed`
 - [P-003 — Tank Royale Rumble](P-003-rumble.md) · `active`
+- [P-005 — TypeScript bot console output reaches the GUI](P-005-typescript-bot-console-output.md) · `draft` — TypeScript bot authors see none of their console output in the GUI, unlike authors on the other three Bot APIs.
 <!-- clue:index:end -->


### PR DESCRIPTION
Bot lifecycle leaked across rounds: a bot thread from a finished round could still dispatch events and send an intent into the next one, and final-turn events could be dropped when the round ended. This branch fixes that and converges all four Bot APIs on the same round-ownership semantics.

## What changed

**Round ownership.** A round is owned by exactly one bot thread. The owning token is invalidated under a lock *before* the superseded thread is woken, so a stale thread that wakes up finds it no longer owns the round and unwinds instead of acting. Java, .NET and Python use the thread field for this; TypeScript, being single-threaded with a Worker, models it with generation counters (run / owner / active-run) that survive nested bot loops.

**Final-turn events always drain.** `flushFinalTurnEvents()` is called from the WebSocket side on game-ended, game-aborted and disconnect, so events queued for the last tick are dispatched even after the bot thread has released ownership. An exception thrown out of `run()` no longer costs the bot its final events.

**Parity fixes.** Position getters fall back to the initial position before the first tick on .NET and TypeScript, matching Java. TypeScript no longer synthesises a duplicate `WonRoundEvent` in `processRoundEnded` (the server already delivers it inside the tick), so `onWonRound` fires once per won round. Python's `_wait_for_next_turn` now checks ownership every iteration and unwinds when no thread owns the round, as Java and .NET do.

**Bounded join on stop.** `stopThread()` joins the outgoing thread with a 1s cap, so a wedged bot delays the next round rather than hanging it.

## Tests

Four cross-platform guarantees are registered in `TEST-REGISTRY.md` as `TR-API-TCK-018` through `-021`, and the implementing tests are tagged with them on each platform.

`TCK-021` (onWonRound fires once per won round) is marked implemented on TypeScript only. TypeScript carried the duplicate-synthesis bug, so it is the only platform with a test proving the guarantee; the other three behave correctly but assert nothing, which is what the red cells record.

Ten shared-corpus cases were added for the initial-position fallback, so all four `SharedTestRunner`s check it identically.

Java 285, .NET 284, TypeScript 296, Python 265, all green.

## Worth knowing before merging

- **Route is simple**, recorded in the final commit's trailers. The branch adds `docs/plans/P-005` and `docs/decisions/PDR-013`, but both ship at `draft` / `inferred` with `accepted-by` empty, so no accepted promise changes here. Accepting P-005 is its own later change.
- **P-005** tracks the remaining C-003 parity residual: the TypeScript Bot API never populates `BotIntent.stdOut` / `stdErr`, so a TypeScript bot's console output never reaches the GUI. Not a mechanical port (Worker boundary, no `process.stdout` in a browser), hence a plan rather than a fix folded in here. Tracked only, not implemented.
- **Pre-existing flake, not from this branch:** `CommandsRadarTest.test_blocking_rescan` times out under full-suite load roughly one run in four. It reproduces on `main` (2 failures in 8 runs) and passes in isolation. Its comment about `go()` returning immediately from non-bot threads is stale after the `go()` alignment, though that is not the failing path.
- **.NET test-host memory:** an early version of one new test spun `Go()` on a `DispatchProxy`, allocating per call, and drove the host out of memory. The host aborts with `Failed: 0` and exit code 0 while silently dropping tests, so watch the reported test count, not just the exit code. Fixed, but a 233-test run was observed before these tests existed, so that suite sits near the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQBFrX6TeMYUXHtXHSSfkD
