### PR TITLE
fix: prevent .NET test output accumulation

### DIFF
--- a/bot-api/dotnet/test/src/test_utils/MockedServer.cs
+++ b/bot-api/dotnet/test/src/test_utils/MockedServer.cs
@@ -126,7 +126,6 @@ public class MockedServer
         });
         // Small delay to ensure server is fully listening
         Thread.Sleep(500);
-        Console.WriteLine($"[Info] Server started at {ServerUrl} (actual port {_port})");
     }
 
     public void Stop()
@@ -430,8 +429,6 @@ public class MockedServer
 
     private void OnMessage(IWebSocketConnection conn, string messageJson)
     {
-        Console.WriteLine("OnMessage: " + messageJson);
-
         var message = JsonConverter.FromJson<Message>(messageJson);
         if (message == null) return;
 


### PR DESCRIPTION
## Summary

Removes unconditional .NET MockedServer console writes for routine server startup and every inbound protocol message. NUnit retains per-test console output, so the raw message logging caused the full suite's test host to exhaust memory.

## Verification

- `./gradlew :bot-api:dotnet:test --no-daemon --max-workers=1` — 284 passed
- `./gradlew clean build --no-daemon --max-workers=1` — passed in 5m 22s
- `clue validate` — passed

Error reporting for timeouts and connection faults remains intact.