### PR TITLE
fix: stabilize .NET blocking rescan test

### DIFF
--- a/bot-api/dotnet/test/src/CommandsRadarTest.cs
+++ b/bot-api/dotnet/test/src/CommandsRadarTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Robocode.TankRoyale.Schema;
 
@@ -17,7 +16,26 @@ public class CommandsRadarTest : AbstractBotTest
 {
     private class RadarTestBot : Bot
     {
+        private int _blockingRescanRequested;
+
         public RadarTestBot(Uri serverUrl) : base(BotInfo, serverUrl) { }
+
+        public override void Run()
+        {
+            while (IsRunning)
+            {
+                if (Interlocked.Exchange(ref _blockingRescanRequested, 0) == 1)
+                {
+                    Rescan();
+                }
+                else
+                {
+                    Go();
+                }
+            }
+        }
+
+        public void RequestBlockingRescan() => Interlocked.Exchange(ref _blockingRescanRequested, 1);
     }
 
     private RadarTestBot StartRadarBot()
@@ -26,6 +44,13 @@ public class CommandsRadarTest : AbstractBotTest
         StartAsync(bot);
         AwaitGameStarted(bot);
         AwaitTick(bot);
+
+        // Drain the initial automatic intent so subsequent captures start cleanly.
+        Server.ResetBotIntentEvent();
+        Server.ContinueBotIntent();
+        AwaitBotIntent();
+        Server.ResetBotIntentEvent();
+
         return bot;
     }
 
@@ -67,8 +92,8 @@ public class CommandsRadarTest : AbstractBotTest
     {
         var bot = StartRadarBot();
 
-        // Run Rescan in a separate task because it's blocking
-        Task.Run(() => bot.Rescan());
+        // Rescan must run on the bot's managed thread because it blocks until the next turn.
+        bot.RequestBlockingRescan();
         AwaitExpectedIntent(intent => intent.Rescan == true);
     }
 


### PR DESCRIPTION
## Summary

Aligns the .NET blocking-rescan test with the Java reference: the request runs on the bot's managed thread, and the initial automatic intent is drained before capture. This removes the timing race that intermittently timed out in `TestBlockingRescan`.

## Verification

- `CommandsRadarTest` repeated five times — all runs passed
- `./gradlew :bot-api:dotnet:test --no-daemon --max-workers=1` — 284 passed
- `./gradlew clean build --no-daemon --max-workers=1` — passed
- `clue validate` — passed